### PR TITLE
Bugfix/hassecret invalid uppercase

### DIFF
--- a/gen/overrides.go
+++ b/gen/overrides.go
@@ -33,6 +33,9 @@ func NewOverrides() Overrides {
 	overrides.Add("user_groups", "search", "id", &FloatField{name: "id"})
 	//overrides.Add("user_tokens", "generate", "token", &FloatField{name: "token"})
 
+	overrides.Add("webhooks", "list", "hasSecret", &BoolField{name: "has_secret"})
+	overrides.Add("webhooks", "create", "hasSecret", &BoolField{name: "has_secret"})
+
 	return overrides
 }
 

--- a/sonarcloud/qualitygates/qualitygates_gen.go
+++ b/sonarcloud/qualitygates/qualitygates_gen.go
@@ -206,9 +206,10 @@ type ShowResponse struct {
 		Metric string  `json:"metric,omitempty"`
 		Op     string  `json:"op,omitempty"`
 	} `json:"conditions,omitempty"`
-	Id        float64 `json:"id,omitempty"`
-	IsBuiltIn bool    `json:"isBuiltIn,omitempty"`
-	Name      string  `json:"name,omitempty"`
+	Id               float64 `json:"id,omitempty"`
+	IsBuiltIn        bool    `json:"isBuiltIn,omitempty"`
+	IsCleanAsYouCode bool    `json:"isCleanAsYouCode,omitempty"`
+	Name             string  `json:"name,omitempty"`
 }
 
 // UnsetDefaultRequest This webservice is no more available : a default quality gate is mandatory.

--- a/sonarcloud/webhooks/webhooks_gen.go
+++ b/sonarcloud/webhooks/webhooks_gen.go
@@ -16,7 +16,7 @@ type CreateRequest struct {
 // CreateResponse is the response for CreateRequest
 type CreateResponse struct {
 	Webhook struct {
-		HasSecret bool   `json:"hasSecret,omitempty"`
+		HasSecret bool   `json:"has_secret,omitempty"`
 		Key       string `json:"key,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Url       string `json:"url,omitempty"`
@@ -104,7 +104,7 @@ type ListResponse struct {
 		Key       string `json:"key,omitempty"`
 		Name      string `json:"name,omitempty"`
 		Url       string `json:"url,omitempty"`
-		HasSecret bool   `json:"hasSecret,omitempty"`
+		HasSecret bool   `json:"has_secret,omitempty"`
 	} `json:"webhooks,omitempty"`
 }
 


### PR DESCRIPTION
the hasSecret attribute from the webhook api generated a struct field of the same name. The uppercase character is incompatible with a tfsdk field (json would have been fine), causing the error.

- add override for hasSecret to has_secret for webhooks /list and /create
- applied pending api update for qualitygates