### PR TITLE
Update to SonarCloud API version 20240528

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2013 The go-github AUTHORS. All rights reserved.
 Copyright (c) 2021 Reinoud Kruithof
+Copyright (c) 2024 Koen van Eijk (ArgonGlow)
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/gen/webservices.json
+++ b/gen/webservices.json
@@ -1,1 +1,7931 @@
-{"webServices":[{"path":"api/authentication","description":"Handle authentication.","actions":[{"key":"logout","description":"Logout a user.","internal":false,"post":true,"hasResponseExample":false,"changelog":[]},{"key":"validate","description":"Check credentials.","internal":false,"post":false,"hasResponseExample":true,"changelog":[]}]},{"path":"api/ce","description":"Get information on Compute Engine tasks.","actions":[{"key":"activity","description":"Search for tasks.\u003cbr\u003e Either componentId or component can be provided, but not both.\u003cbr\u003e Requires the project administration permission if componentId or component is set.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameters \u0027q\u0027 is deprecated","version":"7.6"},{"description":"field \"pullRequest\" added","version":"7.1"},{"description":"fields \"branch\" and \"branchType\" added","version":"6.6"},{"description":"field \"logs\" is deprecated and its value is always false","version":"6.1"},{"description":"it\u0027s no more possible to specify the page parameter.","version":"5.5"}],"params":[{"key":"component","description":"Key of the component (project) to filter on","required":false,"internal":false,"exampleValue":"projectKey"},{"key":"componentId","description":"Id of the component (project) to filter on","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL0","deprecatedSince":"8.0"},{"key":"maxExecutedAt","description":"Maximum date of end of task processing (inclusive)","required":false,"internal":false,"exampleValue":"2017-10-19T13:00:00+0200"},{"key":"minSubmittedAt","description":"Minimum date of task submission (inclusive)","required":false,"internal":false,"exampleValue":"2017-10-19T13:00:00+0200"},{"key":"onlyCurrents","description":"Filter on the last tasks (only the most recent finished task by project)","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 1000","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":1000},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003cli\u003etask ids that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003eMust not be set together with componentId","required":false,"internal":false,"exampleValue":"Apache"},{"key":"status","description":"Comma separated list of task statuses","required":false,"internal":false,"defaultValue":"SUCCESS,FAILED,CANCELED","exampleValue":"IN_PROGRESS,SUCCESS","possibleValues":["SUCCESS","FAILED","CANCELED","PENDING","IN_PROGRESS"]},{"key":"type","description":"Task type","required":false,"internal":false,"exampleValue":"REPORT","possibleValues":["REPORT"]}]},{"key":"activity_status","description":"Returns CE activity related metrics.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"New field \u0027pendingTime\u0027 in response, only included when there are pending tasks","version":"7.8"}],"params":[{"key":"componentId","description":"Id of the component (project) to filter on","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL0"},{"key":"componentKey","description":"Key of the component (project) to filter on","required":false,"internal":false,"exampleValue":"my_project","deprecatedSince":"6.6"}]},{"key":"component","description":"Get the pending tasks, in-progress tasks and the last executed task of a given component (usually a project).\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component.\u003cbr\u003eEither \u0027componentId\u0027 or \u0027component\u0027 must be provided.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \"component\" is deprecated","version":"7.6"},{"description":"fields \"branch\" and \"branchType\" added","version":"6.6"},{"description":"field \"logs\" is deprecated and its value is always false","version":"6.1"}],"params":[{"key":"component","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"componentKey","deprecatedKeySince":"6.6"},{"key":"componentId","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6"}]},{"key":"task","description":"Give Compute Engine task details such as type, status, duration and associated component.\u003cbr /\u003eRequires \u0027Execute Analysis\u0027 permission.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"fields \"branch\" and \"branchType\" added","version":"6.6"}],"params":[{"key":"additionalFields","description":"Comma-separated list of the optional fields to be returned in response.","required":false,"internal":false,"possibleValues":["scannerContext","warnings"]},{"key":"id","description":"Id of task","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"}]}]},{"path":"api/components","description":"Get information about a component (file, directory, project, ...) and its ancestors or descendants. Update a project or module key.","actions":[{"key":"search","description":"Search for projects. Used to provide the ability to search for any component but this option has been removed and webservice \u0027api/components/tree\u0027 should be used instead for this purpose","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"sonar"}]},{"key":"show","description":"Returns a component (file, directory, project) and its ancestors. The ancestors are ordered from the parent to the root project. Requires the following permission: \u0027Browse\u0027 on the project of the specified component.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Component key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"}]},{"key":"tree","description":"Navigate through components based on the chosen strategy.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of \u0027BRC\u0027 as value for parameter \u0027qualifiers\u0027 is deprecated","version":"7.6"},{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Base component key. The search is based on this component.","required":true,"internal":false,"exampleValue":"my_project"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"FILE_NAM","minimumLength":3},{"key":"qualifiers","description":"Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"possibleValues":["BRC","DIR","FIL","TRK","UTS"]},{"key":"s","description":"Comma-separated list of sort fields","required":false,"internal":false,"defaultValue":"name","exampleValue":"name, path","possibleValues":["name","path","qualifier"]},{"key":"strategy","description":"Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"defaultValue":"all","possibleValues":["all","children","leaves"]}]}]},{"path":"api/duplications","description":"Get duplication information for a project.","actions":[{"key":"show","description":"Get duplications. Require Browse permission on file\u0027s project","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The fields \u0027uuid\u0027, \u0027projectUuid\u0027, \u0027subProjectUuid\u0027 are deprecated in the response.","version":"6.5"}],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"key","description":"File key","required":false,"internal":false,"exampleValue":"my_project:/src/foo/Bar.php"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"},{"key":"uuid","description":"File ID. If provided, \u0027key\u0027 must not be provided.","required":false,"internal":false,"exampleValue":"584a89f2-8037-4f7b-b82c-8b45d2d63fb2","deprecatedSince":"6.5"}]}]},{"path":"api/favorites","description":"Manage user favorites","actions":[{"key":"add","description":"Add a project as favorite for the authenticated user.\u003cbr\u003eOnly 100 components can be added as favorite.\u003cbr\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"It\u0027s no longer possible to have more than 100 favorites by qualifier","version":"7.7"},{"description":"It\u0027s no longer possible to set a directory as favorite","version":"7.7"},{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"component","description":"Component key. Only components with qualifier TRK are supported","required":true,"internal":false,"exampleValue":"my_project:/src/foo/Bar.php"}]},{"key":"remove","description":"Remove a component (project, directory, file etc.) as favorite for the authenticated user.\u003cbr\u003eRequires authentication.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"component","description":"Component key","required":true,"internal":false,"exampleValue":"my_project"}]},{"key":"search","description":"Search for the authenticated user favorites.\u003cbr\u003eRequires authentication.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500}]}]},{"path":"api/favourites","description":"Removed since 6.3, please use api/favorites instead","actions":[{"key":"index","description":"The web service is removed and you\u0027re invited to use api/favorites instead","deprecatedSince":"6.3","internal":false,"post":false,"hasResponseExample":true,"changelog":[]}]},{"path":"api/issues","description":"Read and update issues.","actions":[{"key":"add_comment","description":"Add a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"},{"description":"the response returns the issue with all its details","version":"6.3"}],"params":[{"key":"isFeedback","description":"Define is the given comment is a feedback","required":false,"internal":false,"defaultValue":"false","exampleValue":"true"},{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"text","description":"Comment text","required":true,"internal":false,"exampleValue":"Won\u0027t fix because it doesn\u0027t apply to the context"}]},{"key":"assign","description":"Assign/Unassign an issue. Requires authentication and Browse permission on project","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"}],"params":[{"key":"assignee","description":"Login of the assignee. When not set, it will unassign the issue. Use \u0027_me\u0027 to assign to current user","required":false,"internal":false,"exampleValue":"admin"},{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"}]},{"key":"authors","description":"Search SCM accounts which match a given query.\u003cbr/\u003eRequires authentication.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The maximum size of \u0027ps\u0027 is set to 100","version":"7.4"}],"params":[{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 100","required":false,"internal":false,"defaultValue":"10","exampleValue":"20","maximumValue":100},{"key":"q","description":"Limit search to authors that contain the supplied string.","required":false,"internal":false,"exampleValue":"luke"}]},{"key":"bulk_change","description":"Bulk change on issues.\u003cbr/\u003eRequires authentication.","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"\u0027actions\u0027 parameter is ignored","version":"6.3"}],"params":[{"key":"add_tags","description":"Add tags","required":false,"internal":false,"exampleValue":"security,java8","deprecatedKey":"add_tags.tags","deprecatedKeySince":"6.2"},{"key":"assign","description":"To assign the list of issues to a specific user (login), or un-assign all the issues","required":false,"internal":false,"exampleValue":"john.smith","deprecatedKey":"assign.assignee","deprecatedKeySince":"6.2"},{"key":"comment","description":"To add a comment to a list of issues","required":false,"internal":false,"exampleValue":"Here is my comment"},{"key":"do_transition","description":"Transition","required":false,"internal":false,"exampleValue":"reopen","deprecatedKey":"do_transition.transition","deprecatedKeySince":"6.2","possibleValues":["confirm","unconfirm","reopen","resolve","falsepositive","wontfix","close","setinreview","resolveasreviewed","resetastoreview"]},{"key":"issues","description":"Comma-separated list of issue keys","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy,AU-TpxcA-iU5OvuD2FLz"},{"key":"remove_tags","description":"Remove tags","required":false,"internal":false,"exampleValue":"security,java8","deprecatedKey":"remove_tags.tags","deprecatedKeySince":"6.2"},{"key":"sendNotifications","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"set_severity","description":"To change the severity of the list of issues","required":false,"internal":false,"exampleValue":"BLOCKER","deprecatedKey":"set_severity.severity","deprecatedKeySince":"6.2","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"set_type","description":"To change the type of the list of issues","required":false,"internal":false,"exampleValue":"BUG","deprecatedKey":"set_type.type","deprecatedKeySince":"6.2","possibleValues":["CODE_SMELL","BUG","VULNERABILITY","SECURITY_HOTSPOT"]}]},{"key":"changelog","description":"Display changelog of an issue.\u003cbr/\u003eRequires the \u0027Browse\u0027 permission on the project of the specified issue.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"changes on effort is expressed with the raw value in minutes (instead of the duration previously)","version":"6.3"}],"params":[{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"}]},{"key":"delete_comment","description":"Delete a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"},{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response returns the issue with all its details","version":"6.3"},{"description":"the \u0027key\u0027 parameter is renamed \u0027comment\u0027","version":"6.3"}],"params":[{"key":"comment","description":"Comment key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedKey":"key","deprecatedKeySince":"6.3"}]},{"key":"do_transition","description":"Do workflow transition on an issue. Requires authentication and Browse permission on project.\u003cbr/\u003eThe transitions \u0027wontfix\u0027 and \u0027falsepositive\u0027 require the permission \u0027Administer Issues\u0027.\u003cbr/\u003eThe transitions involving security hotspots require the permission \u0027Administer Security Hotspot\u0027.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"transition","description":"Transition","required":true,"internal":false,"possibleValues":["confirm","unconfirm","reopen","resolve","falsepositive","wontfix","close","setinreview","resolveasreviewed","resetastoreview"]}]},{"key":"edit_comment","description":"Edit a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"},{"description":"the response returns the issue with all its details","version":"6.3"},{"description":"the \u0027key\u0027 parameter has been renamed comment","version":"6.3"}],"params":[{"key":"comment","description":"Comment key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedKey":"key","deprecatedKeySince":"6.3"},{"key":"text","description":"Comment text","required":true,"internal":false,"exampleValue":"Won\u0027t fix because it doesn\u0027t apply to the context"}]},{"key":"search","description":"Search for issues.\u003cbr\u003eRequires the \u0027Browse\u0027 permission on the specified project(s).","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"additionalFields","description":"Comma-separated list of the optional fields to be returned in response. Action plans are dropped in 5.5, it is not returned in the response.","required":false,"internal":false,"possibleValues":["_all","comments","languages","actionPlans","rules","transitions","actions","users"]},{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"assigned","description":"To retrieve assigned or unassigned issues","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"assignees","description":"Comma-separated list of assignee logins. The value \u0027__me__\u0027 can be used as a placeholder for user who performs the request","required":false,"internal":false,"exampleValue":"admin,usera,__me__"},{"key":"author","description":"SCM accounts. To set several values, the parameter must be called once for each value.","required":false,"internal":false,"exampleValue":"author\u003dtorvalds@linux-foundation.org\u0026author\u003dlinux@fondation.org"},{"key":"authors","description":"This parameter is deprecated, please use \u0027author\u0027 instead","required":false,"internal":false,"exampleValue":"torvalds@linux-foundation.org","deprecatedSince":"7.7"},{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"componentKeys","description":"Comma-separated list of component keys. Retrieve issues associated to a specific list of components (and all its descendants). A component can be a project, directory or file.","required":false,"internal":false,"exampleValue":"my_project"},{"key":"createdAfter","description":"To retrieve issues created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided. \u003cbr\u003eIf this parameter is set, createdSince must not be set","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"createdAt","description":"Datetime to retrieve issues created during a specific analysis","required":false,"internal":false,"exampleValue":"2017-10-19T13:00:00+0200"},{"key":"createdBefore","description":"To retrieve issues created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"createdInLast","description":"To retrieve issues created during a time span before the current time (exclusive). Accepted units are \u0027y\u0027 for year, \u0027m\u0027 for month, \u0027w\u0027 for week and \u0027d\u0027 for day. If this parameter is set, createdAfter must not be set","required":false,"internal":false,"exampleValue":"1m2w (1 month 2 weeks)"},{"key":"cwe","description":"Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select issues not associated to any CWE.","required":false,"internal":false,"exampleValue":"12,125,unknown"},{"key":"facetMode","description":"Choose the returned value for facet items, either count of issues or sum of remediation effort.","required":false,"internal":false,"defaultValue":"count","deprecatedSince":"7.9","possibleValues":["count","effort"]},{"key":"facets","description":"Comma-separated list of the facets to be computed. No facet is computed by default.","required":false,"internal":false,"possibleValues":["projects","moduleUuids","fileUuids","assigned_to_me","severities","statuses","resolutions","rules","assignees","authors","author","directories","languages","tags","types","owaspTop10","sansTop25","cwe","createdAt","sonarsourceSecurity"]},{"key":"issues","description":"Comma-separated list of issue keys","required":false,"internal":false,"exampleValue":"5bccd6e8-f525-43a2-8d76-fcb13dde79ef"},{"key":"languages","description":"Comma-separated list of languages. Available since 4.4","required":false,"internal":false,"exampleValue":"java,js"},{"key":"onComponentOnly","description":"Return only issues at a component\u0027s level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"organization","description":"Organization key","required":false,"internal":false,"exampleValue":"my-org"},{"key":"owaspTop10","description":"Comma-separated list of OWASP Top 10 lowercase categories.","required":false,"internal":false,"possibleValues":["a1","a2","a3","a4","a5","a6","a7","a8","a9","a10"]},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"},{"key":"resolutions","description":"Comma-separated list of resolutions","required":false,"internal":false,"exampleValue":"FIXED,REMOVED","possibleValues":["FALSE-POSITIVE","WONTFIX","FIXED","REMOVED"]},{"key":"resolved","description":"To match resolved or unresolved issues","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"rules","description":"Comma-separated list of coding rule keys. Format is \u0026lt;repository\u0026gt;:\u0026lt;rule\u0026gt;","required":false,"internal":false,"exampleValue":"squid:AvoidCycles"},{"key":"s","description":"Sort field","required":false,"internal":false,"possibleValues":["CREATION_DATE","UPDATE_DATE","CLOSE_DATE","ASSIGNEE","SEVERITY","STATUS","FILE_LINE","HOTSPOTS"]},{"key":"sansTop25","description":"Comma-separated list of SANS Top 25 categories.","required":false,"internal":false,"possibleValues":["insecure-interaction","risky-resource","porous-defenses"]},{"key":"severities","description":"Comma-separated list of severities","required":false,"internal":false,"exampleValue":"BLOCKER,CRITICAL","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"sinceLeakPeriod","description":"To retrieve issues created since the leak period.\u003cbr\u003eIf this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"sonarsourceSecurity","description":"Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select issues not associated with any category","required":false,"internal":false,"possibleValues":["sql-injection","command-injection","path-traversal-injection","ldap-injection","xpath-injection","rce","dos","ssrf","csrf","xss","log-injection","http-response-splitting","open-redirect","xxe","object-injection","weak-cryptography","auth","insecure-conf","encrypt-data","traceability","file-manipulation","others"]},{"key":"statuses","description":"Comma-separated list of statuses","required":false,"internal":false,"exampleValue":"OPEN,REOPENED","possibleValues":["OPEN","CONFIRMED","REOPENED","RESOLVED","CLOSED"]},{"key":"tags","description":"Comma-separated list of tags.","required":false,"internal":false,"exampleValue":"security,convention"},{"key":"types","description":"Comma-separated list of types.","required":false,"internal":false,"exampleValue":"CODE_SMELL,BUG","possibleValues":["CODE_SMELL","BUG","VULNERABILITY"]}]},{"key":"set_severity","description":"Change severity.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"}],"params":[{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"severity","description":"New severity","required":true,"internal":false,"possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]}]},{"key":"set_tags","description":"Set tags on an issue. \u003cbr/\u003eRequires authentication and Browse permission on project","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"},{"description":"response contains issue information instead of list of tags","version":"6.4"}],"params":[{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedKey":"key","deprecatedKeySince":"6.3"},{"key":"tags","description":"Comma-separated list of tags. All tags are removed if parameter is empty or not set.","required":false,"internal":false,"exampleValue":"security,cwe,misra-c"}]},{"key":"set_type","description":"Change type of issue, for instance from \u0027code smell\u0027 to \u0027bug\u0027.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"the database ids of the components are removed from the response","version":"6.5"},{"description":"the response field components.uuid is deprecated. Use components.key instead.","version":"6.5"}],"params":[{"key":"issue","description":"Issue key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"type","description":"New type","required":true,"internal":false,"possibleValues":["CODE_SMELL","BUG","VULNERABILITY"]}]},{"key":"tags","description":"List tags matching a given query","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Result doesn\u0027t include rules tags anymore","version":"7.4"}],"params":[{"key":"organization","description":"Organization key","required":false,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 100","required":false,"internal":false,"defaultValue":"10","exampleValue":"20","maximumValue":100},{"key":"q","description":"Limit search to tags that contain the supplied string.","required":false,"internal":false,"exampleValue":"misra"}]}]},{"path":"api/languages","description":"Get the list of programming languages supported in this instance.","actions":[{"key":"list","description":"List supported programming languages","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"ps","description":"The size of the list to return, 0 for all languages","required":false,"internal":false,"defaultValue":"0","exampleValue":"25"},{"key":"q","description":"A pattern to match language keys/names against","required":false,"internal":false,"exampleValue":"java"}]}]},{"path":"api/measures","description":"Get components or children with specified measures.","actions":[{"key":"component","description":"Return component with specified measures. The componentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the project of specified component.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"},{"description":"the response field id is deprecated. Use key instead.","version":"6.6"},{"description":"the response field refId is deprecated. Use refKey instead.","version":"6.6"}],"params":[{"key":"additionalFields","description":"Comma-separated list of additional fields that can be returned in the response.","required":false,"internal":false,"exampleValue":"periods,metrics","possibleValues":["metrics","periods"]},{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Component key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"componentKey","deprecatedKeySince":"6.6"},{"key":"componentId","description":"Component id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6"},{"key":"developerId","description":"Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.","required":false,"internal":false,"deprecatedSince":"6.4"},{"key":"developerKey","description":"Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.","required":false,"internal":false,"deprecatedSince":"6.4"},{"key":"metricKeys","description":"Comma-separated list of metric keys","required":true,"internal":false,"exampleValue":"ncloc,complexity,violations"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"}]},{"key":"component_tree","description":"Navigate through components based on the chosen strategy with specified measures. The baseComponentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"},{"description":"field \u0027bestValue\u0027 is added to the response","version":"7.2"},{"description":"the response field id is deprecated. Use key instead.","version":"6.6"},{"description":"the response field refId is deprecated. Use refKey instead.","version":"6.6"},{"description":"Number of metric keys is limited to 15","version":"6.3"}],"params":[{"key":"additionalFields","description":"Comma-separated list of additional fields that can be returned in the response.","required":false,"internal":false,"exampleValue":"periods,metrics","possibleValues":["metrics","periods"]},{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"baseComponentId","description":"Base component id. The search is based on this component.","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FLz","deprecatedSince":"6.6"},{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Component key. The search is based on this component.","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"baseComponentKey","deprecatedKeySince":"6.6"},{"key":"developerId","description":"Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.","required":false,"internal":false,"deprecatedSince":"6.4"},{"key":"developerKey","description":"Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.","required":false,"internal":false,"deprecatedSince":"6.4"},{"key":"metricKeys","description":"Comma-separated list of metric keys. Types DISTRIB, DATA are not allowed.","required":true,"internal":false,"exampleValue":"ncloc,complexity,violations","maxValuesAllowed":15},{"key":"metricPeriodSort","description":"Sort measures by leak period or not ?. The \u0027s\u0027 parameter must contain the \u0027metricPeriod\u0027 value.","required":false,"internal":false,"possibleValues":["1"]},{"key":"metricSort","description":"Metric key to sort by. The \u0027s\u0027 parameter must contain the \u0027metric\u0027 or \u0027metricPeriod\u0027 value. It must be part of the \u0027metricKeys\u0027 parameter","required":false,"internal":false,"exampleValue":"ncloc"},{"key":"metricSortFilter","description":"Filter components. Sort must be on a metric. Possible values are: \u003cul\u003e\u003cli\u003eall: return all components\u003c/li\u003e\u003cli\u003ewithMeasuresOnly: filter out components that do not have a measure on the sorted metric\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"defaultValue":"all","possibleValues":["all","withMeasuresOnly"]},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"FILE_NAM","minimumLength":3},{"key":"qualifiers","description":"Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"possibleValues":["BRC","DIR","FIL","TRK","UTS"]},{"key":"s","description":"Comma-separated list of sort fields","required":false,"internal":false,"defaultValue":"name","exampleValue":"name,path","possibleValues":["metric","metricPeriod","name","path","qualifier"]},{"key":"strategy","description":"Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"defaultValue":"all","possibleValues":["all","children","leaves"]}]},{"key":"search_history","description":"Search measures history of a component.\u003cbr\u003eMeasures are ordered chronologically.\u003cbr\u003ePagination applies to the number of measures for each metric.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Component key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"from","description":"Filter measures created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"metrics","description":"Comma-separated list of metric keys","required":true,"internal":false,"exampleValue":"ncloc,coverage,new_violations"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 1000","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":1000},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"},{"key":"to","description":"Filter measures created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"}]}]},{"path":"api/metrics","description":"Get information on automatic metrics, and manage custom metrics. See also api/custom_measures.","actions":[{"key":"domains","description":"List all custom metric domains.","deprecatedSince":"7.7","internal":false,"post":false,"hasResponseExample":true,"changelog":[]},{"key":"search","description":"Search for metrics","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"f","description":"Comma-separated list of the fields to be returned in response. All the fields are returned by default.","required":false,"internal":false,"deprecatedSince":"7.7","possibleValues":["name","description","domain","direction","qualitative","hidden","decimalScale"]},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500}]},{"key":"types","description":"List all available metric types.","internal":false,"post":false,"hasResponseExample":true,"changelog":[]}]},{"path":"api/notifications","description":"Manage notifications of the authenticated user","actions":[{"key":"add","description":"Add a notification for the authenticated user.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e \u003cli\u003eAuthentication if no login is provided. If a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e \u003cli\u003eIf a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"channel","description":"Channel through which the notification is sent. For example, notifications can be sent by email.","required":false,"internal":false,"defaultValue":"EmailNotificationChannel","possibleValues":["EmailNotificationChannel"]},{"key":"login","description":"User login","required":false,"internal":false},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"type","description":"Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"exampleValue":"SQ-MyNewIssues"}]},{"key":"list","description":"List notifications of the authenticated user","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"login","description":"User login","required":false,"internal":false}]},{"key":"remove","description":"Remove a notification for the authenticated user","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"channel","description":"Channel through which the notification is sent. For example, notifications can be sent by email.","required":false,"internal":false,"defaultValue":"EmailNotificationChannel","possibleValues":["EmailNotificationChannel"]},{"key":"login","description":"User login","required":false,"internal":false},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"type","description":"Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"exampleValue":"SQ-MyNewIssues"}]}]},{"path":"api/permissions","description":"Manage permission templates, and the granting and revoking of permissions at the global and project levels.","actions":[{"key":"add_group","description":"Add permission to a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group name or group id must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"groupId","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"groupName","description":"Group name or \u0027anyone\u0027 (case insensitive)","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"add_group_to_template","description":"Add a group to a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"groupId","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"groupName","description":"Group name or \u0027anyone\u0027 (case insensitive)","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"add_project_creator_to_template","description":"Add a project creator to a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"add_user","description":"Add permission to a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"If organizationKey and projectId are both set, the organizationKey must be the key of the organization of the project","version":"7.4"}],"params":[{"key":"login","description":"User login","required":true,"internal":false,"exampleValue":"g.hopper"},{"key":"organization","description":"Key of organization, used when group name is set","required":true,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"add_user_to_template","description":"Add a user to a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"login","description":"User login","required":true,"internal":false,"exampleValue":"g.hopper"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"apply_template","description":"Apply a permission template to one project.\u003cbr\u003eThe project id or project key must be provided.\u003cbr\u003eThe template id or name must be provided.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"bulk_apply_template","description":"Apply a permission template to several projects.\u003cbr /\u003eThe template id or name must be provided.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"Parameter projects accepts maximum 1000 values","version":"6.7.2"}],"params":[{"key":"analyzedBefore","description":"Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"onProvisionedOnly","description":"Filter the projects that are provisioned","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"projects","description":"Comma-separated list of project keys","required":false,"internal":false,"exampleValue":"my_project,another_project","maxValuesAllowed":1000},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"apac"},{"key":"qualifiers","description":"Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"defaultValue":"TRK","deprecatedKey":"qualifier","deprecatedKeySince":"6.6","possibleValues":["TRK"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"create_template","description":"Create a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"description","description":"Description","required":false,"internal":false,"exampleValue":"Permissions for all projects related to the financial service"},{"key":"name","description":"Name","required":true,"internal":false,"exampleValue":"Financial Service Permissions"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"projectKeyPattern","description":"Project key pattern. Must be a valid Java regular expression","required":false,"internal":false,"exampleValue":".*\\.finance\\..*"}]},{"key":"delete_template","description":"Delete a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"remove_group","description":"Remove a permission from a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group id or group name must be provided, not both.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"groupId","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"groupName","description":"Group name or \u0027anyone\u0027 (case insensitive)","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"remove_group_from_template","description":"Remove a group from a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"groupId","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"groupName","description":"Group name or \u0027anyone\u0027 (case insensitive)","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"remove_project_creator_from_template","description":"Remove a project creator from a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"remove_user","description":"Remove permission from a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"login","description":"User login","required":true,"internal":false,"exampleValue":"g.hopper"},{"key":"organization","description":"Key of organization, used when group name is set","required":true,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"remove_user_from_template","description":"Remove a user from a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"login","description":"User login","required":true,"internal":false,"exampleValue":"g.hopper"},{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"permission","description":"Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"possibleValues":["admin","codeviewer","issueadmin","securityhotspotadmin","scan","user"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"search_global_permissions","description":"List global permissions. \u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027","deprecatedSince":"6.5","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"search_project_permissions","description":"List project permissions. A project can be a technical project, a view or a developer.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.","deprecatedSince":"6.5","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"ce4c03d6-430f-40a9-b777-ad877c00aa4d"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"ps","description":"Page size. Must be greater than 0.","required":false,"internal":false,"defaultValue":"25","exampleValue":"20"},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"apac"},{"key":"qualifier","description":"Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"possibleValues":["TRK"]}]},{"key":"search_templates","description":"List permission templates.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":false,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"q","description":"Limit search to permission template names that contain the supplied string.","required":false,"internal":false,"exampleValue":"defau"}]},{"key":"set_default_template","description":"Set a permission template as default.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"organization","description":"Key of organization, used when group name is set","required":false,"internal":false,"exampleValue":"my-org"},{"key":"qualifier","description":"Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"defaultValue":"TRK","possibleValues":["TRK"]},{"key":"templateId","description":"Template id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"templateName","description":"Template name","required":false,"internal":false,"exampleValue":"Default Permission Template for Projects"}]},{"key":"update_template","description":"Update a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"description","description":"Description","required":false,"internal":false,"exampleValue":"Permissions for all projects related to the financial service"},{"key":"id","description":"Id","required":true,"internal":false,"exampleValue":"af8cb8cc-1e78-4c4e-8c00-ee8e814009a5"},{"key":"name","description":"Name","required":false,"internal":false,"exampleValue":"Financial Service Permissions"},{"key":"projectKeyPattern","description":"Project key pattern. Must be a valid Java regular expression","required":false,"internal":false,"exampleValue":".*\\.finance\\..*"}]}]},{"path":"api/project_analyses","description":"Manage project analyses.","actions":[{"key":"create_event","description":"Create a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be created.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"analysis","description":"Analysis key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"category","description":"Category","required":false,"internal":false,"defaultValue":"OTHER","possibleValues":["VERSION","OTHER"]},{"key":"name","description":"Name","required":true,"internal":false,"exampleValue":"5.6","maximumLength":400}]},{"key":"delete","description":"Delete a project analysis.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the project of the specified analysis.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"analysis","description":"Analysis key","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL1"}]},{"key":"delete_event","description":"Delete a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be deleted.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"event","description":"Event key","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FLz"}]},{"key":"search","description":"Search a project analyses and attached events.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Add QualityGate information on Applications","version":"7.5"}],"params":[{"key":"branch","description":"Key of a long lived branch","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"category","description":"Event category. Filter analyses that have at least one event of the category specified.","required":false,"internal":false,"exampleValue":"OTHER","possibleValues":["VERSION","OTHER","QUALITY_PROFILE","QUALITY_GATE","DEFINITION_CHANGE"]},{"key":"from","description":"Filter analyses created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided","required":false,"internal":false,"exampleValue":"2013-05-01"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"to","description":"Filter analyses created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"}]},{"key":"set_baseline","description":"Set an analysis as the baseline of the New Code Period on a project or a long-lived branch.\u003cbr/\u003eThis manually set baseline overrides the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"analysis","description":"Analysis key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"branch","description":"Branch key","required":false,"internal":false},{"key":"project","description":"Project key","required":true,"internal":false}]},{"key":"unset_baseline","description":"Unset any manually-set New Code Period baseline on a project or a long-lived branch.\u003cbr/\u003eUnsetting a manual baseline restores the use of the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false},{"key":"project","description":"Project key","required":true,"internal":false}]},{"key":"update_event","description":"Update a project analysis event.\u003cbr\u003eOnly events of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be updated.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"event","description":"Event key","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL5"},{"key":"name","description":"New name","required":true,"internal":false,"exampleValue":"5.6","maximumLength":400}]}]},{"path":"api/project_badges","description":"Generate badges based on quality gates or measures","actions":[{"key":"measure","description":"Generate badge for project\u0027s measure as an SVG.\u003cbr/\u003eRequires a security token for private projects.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"branch","description":"Long-lived branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"metric","description":"Metric key","required":true,"internal":false,"possibleValues":["bugs","code_smells","coverage","duplicated_lines_density","ncloc","sqale_rating","alert_status","reliability_rating","security_rating","sqale_index","vulnerabilities"]},{"key":"project","description":"Project or application key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"token","description":"Security token","required":false,"internal":false}]},{"key":"quality_gate","description":"Generate badge for project\u0027s quality gate as an SVG.\u003cbr/\u003eRequires a security token for private projects.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"branch","description":"Long-lived branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"project","description":"Project or application key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"token","description":"Security token","required":false,"internal":false}]}]},{"path":"api/project_branches","description":"Manage branch (only available when the Branch plugin is installed)","actions":[{"key":"delete","description":"Delete a non-main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"branch","description":"Name of the branch","required":true,"internal":false,"exampleValue":"branch1"},{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"}]},{"key":"list","description":"List the branches of a project.\u003cbr/\u003eRequires \u0027Browse\u0027 or \u0027Execute analysis\u0027 rights on the specified project.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Application can be used on this web service","version":"7.2"}],"params":[{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"}]},{"key":"rename","description":"Rename the main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 permission on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"name","description":"New name of the main branch","required":true,"internal":false,"exampleValue":"branch1","maximumLength":255},{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"}]}]},{"path":"api/project_links","description":"Manage projects links.","actions":[{"key":"create","description":"Create a new project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"name","description":"Link name","required":true,"internal":false,"exampleValue":"Custom","maximumLength":128},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"url","description":"Link url","required":true,"internal":false,"exampleValue":"http://example.com","maximumLength":2048}]},{"key":"delete","description":"Delete existing project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"Link id","required":true,"internal":false,"exampleValue":"17"}]},{"key":"search","description":"List links of a project.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"projectId","description":"Project Id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"projectKey","description":"Project Key","required":false,"internal":false,"exampleValue":"my_project"}]}]},{"path":"api/project_pull_requests","description":"Manage pull request (only available when the Branch plugin is installed)","actions":[{"key":"delete","description":"Delete a pull request.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"pullRequest","description":"Pull request id","required":true,"internal":false,"exampleValue":"1543"}]},{"key":"list","description":"List the pull requests of a project.\u003cbr/\u003eOne of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Browse\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Execute Analysis\u0027 rights on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"}]}]},{"path":"api/project_tags","description":"Manage project tags","actions":[{"key":"search","description":"Search tags","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 100","required":false,"internal":false,"defaultValue":"10","exampleValue":"20","maximumValue":100},{"key":"q","description":"Limit search to tags that contain the supplied string.","required":false,"internal":false,"exampleValue":"off"}]},{"key":"set","description":"Set tags on a project.\u003cbr\u003eRequires the following permission: \u0027Administer\u0027 rights on the specified project","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"tags","description":"Comma-separated list of tags","required":true,"internal":false,"exampleValue":"finance, offshore"}]}]},{"path":"api/projects","description":"Manage project existence.","actions":[{"key":"bulk_delete","description":"Delete one or several projects.\u003cbr /\u003eOnly the 1\u0027000 first items in project filters are taken into account.\u003cbr /\u003eRequires \u0027Administer System\u0027 permission.\u003cbr /\u003eAt least one parameter is required among analyzedBefore, projects and q","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"At least one parameter is required among analyzedBefore, projects and q","version":"7.8"}],"params":[{"key":"analyzedBefore","description":"Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"onProvisionedOnly","description":"Filter the projects that are provisioned","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"organization","description":"The key of the organization","required":true,"internal":false},{"key":"projects","description":"Comma-separated list of project keys","required":false,"internal":false,"exampleValue":"my_project,another_project"},{"key":"q","description":"Limit to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"sonar"},{"key":"qualifiers","description":"No longer used","required":false,"internal":false,"defaultValue":"TRK","deprecatedSince":"8.0","possibleValues":["TRK"]}]},{"key":"bulk_update_key","description":"Bulk update a project or module key and all its sub-components keys. The bulk update allows to replace a part of the current key by another string on the current project and all its sub-modules.\u003cbr\u003eIt\u0027s possible to simulate the bulk update by setting the parameter \u0027dryRun\u0027 at true. No key is updated with a dry run.\u003cbr\u003eEx: to rename a project with key \u0027my_project\u0027 to \u0027my_new_project\u0027 and all its sub-components keys, call the WS with parameters:\u003cul\u003e  \u003cli\u003eproject: my_project\u003c/li\u003e  \u003cli\u003efrom: my_\u003c/li\u003e  \u003cli\u003eto: my_new_\u003c/li\u003e\u003c/ul\u003eRequires the permission \u0027Administer\u0027 on the specified project.","deprecatedSince":"7.6","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"dryRun","description":"Simulate bulk update. No component key is updated.","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"from","description":"String to match in components keys","required":true,"internal":false,"exampleValue":"_old"},{"key":"project","description":"Project or module key","required":true,"internal":false,"exampleValue":"my_old_project"},{"key":"to","description":"String replacement in components keys","required":true,"internal":false,"exampleValue":"_new"}]},{"key":"create","description":"Create a project.\u003cbr/\u003eRequires \u0027Create Projects\u0027 permission","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"The \u0027visibility\u0027 parameter is public","version":"7.1"}],"params":[{"key":"branch","description":"SCM Branch of the project. The key of the project will become key:branch, for instance \u0027SonarQube:branch-5.0\u0027","required":false,"internal":false,"exampleValue":"branch-5.0","deprecatedSince":"7.8"},{"key":"name","description":"Name of the project. If name is longer than 500, it is abbreviated.","required":true,"internal":false,"exampleValue":"SonarQube"},{"key":"organization","description":"The key of the organization","required":true,"internal":false},{"key":"project","description":"Key of the project","required":true,"internal":false,"exampleValue":"my_project","maximumLength":400},{"key":"visibility","description":"Whether the created project should be visible to everyone, or only specific user/groups.\u003cbr/\u003eIf no visibility is specified, the default project visibility of the organization will be used.","required":false,"internal":false,"possibleValues":["private","public"]}]},{"key":"delete","description":"Delete a project.\u003cbr\u003e Requires \u0027Administer System\u0027 permission or \u0027Administer\u0027 permission on the project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"search","description":"Search for projects to administrate them.\u003cbr\u003eRequires \u0027System Administrator\u0027 permission","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"analyzedBefore","description":"Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"onProvisionedOnly","description":"Filter the projects that are provisioned","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"organization","description":"The key of the organization","required":true,"internal":false},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"projects","description":"Comma-separated list of project keys","required":false,"internal":false,"exampleValue":"my_project,another_project","maxValuesAllowed":1000},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"q","description":"Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"sonar"},{"key":"qualifiers","description":"No longer used","required":false,"internal":false,"defaultValue":"TRK","deprecatedSince":"8.0","possibleValues":["TRK"]}]},{"key":"update_key","description":"Update a project or module key and all its sub-components keys.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"Ability to update key of a disabled module","version":"7.1"}],"params":[{"key":"from","description":"Project or module key","required":true,"internal":false,"exampleValue":"my_old_project"},{"key":"to","description":"New component key","required":true,"internal":false,"exampleValue":"my_new_project"}]},{"key":"update_visibility","description":"Updates visibility of a project.\u003cbr\u003eRequires \u0027Project administer\u0027 permission on the specified project","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"},{"key":"visibility","description":"New visibility","required":true,"internal":false,"possibleValues":["private","public"]}]}]},{"path":"api/properties","description":"This web service is deprecated, please use api/settings instead.","actions":[{"key":"index","description":"This web service is deprecated, please use api/settings/values instead.","deprecatedSince":"6.3","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"format","description":"Only json response format is available","required":false,"internal":false,"possibleValues":["json"]},{"key":"id","description":"Setting key","required":false,"internal":false,"exampleValue":"sonar.test.inclusions"},{"key":"resource","description":"Component key or database id","required":false,"internal":false,"exampleValue":"my_project"}]}]},{"path":"api/qualitygates","description":"Manage quality gates, including conditions and project association.","actions":[{"key":"copy","description":"Copy a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"The ID of the source quality gate","required":true,"internal":false,"exampleValue":"1"},{"key":"name","description":"The name of the quality gate to create","required":true,"internal":false,"exampleValue":"My Quality Gate"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"create","description":"Create a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"name","description":"The name of the quality gate to create","required":true,"internal":false,"exampleValue":"My Quality Gate","maximumLength":100},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"create_condition","description":"Add a new condition to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters","version":"7.6"},{"description":"Made \u0027error\u0027 parameter mandatory","version":"7.6"},{"description":"Reduced the possible values of \u0027op\u0027 parameter to LT and GT","version":"7.6"}],"params":[{"key":"error","description":"Condition error threshold","required":true,"internal":false,"exampleValue":"10","maximumLength":64},{"key":"gateId","description":"ID of the quality gate","required":true,"internal":false,"exampleValue":"1"},{"key":"metric","description":"Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"exampleValue":"blocker_violations, vulnerabilities, new_code_smells"},{"key":"op","description":"Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"GT","possibleValues":["LT","GT"]},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"delete_condition","description":"Delete a condition from a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"Condition ID","required":true,"internal":false,"exampleValue":"2"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"deselect","description":"Remove the association of a project from a quality gate.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer Quality Gates\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"The parameter \u0027gateId\u0027 was removed","version":"6.6"}],"params":[{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"projectId","description":"Project id","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.1"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"destroy","description":"Delete a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"ID of the quality gate to delete","required":true,"internal":false,"exampleValue":"1"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"get_by_project","description":"Get the quality gate of a project.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The parameter \u0027projectId\u0027 has been removed","version":"6.6"},{"description":"The parameter \u0027projectKey\u0027 has been renamed to \u0027project\u0027","version":"6.6"},{"description":"This webservice is now part of the public API","version":"6.6"}],"params":[{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":true,"internal":false,"exampleValue":"my_project"}]},{"key":"list","description":"Get a list of quality gates","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"\u0027isDefault\u0027 field is added on quality gate","version":"7.0"},{"description":"\u0027default\u0027 field on root level is deprecated","version":"7.0"},{"description":"\u0027isBuiltIn\u0027 field is added in the response","version":"7.0"},{"description":"\u0027actions\u0027 fields are added in the response","version":"7.0"}],"params":[{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"project_status","description":"Get the quality gate status of a project or a Compute Engine task.\u003cbr /\u003eEither \u0027analysisId\u0027, \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided\u003cbr /\u003eThe different statuses returned are: OK, WARN, ERROR, NONE. The NONE status is returned when there is no quality gate associated with the analysis.\u003cbr /\u003eReturns an HTTP code 404 if the analysis associated with the task is not found or does not exist.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The parameters \u0027branch\u0027 and \u0027pullRequest\u0027 were added","version":"7.7"},{"description":"The field \u0027warning\u0027 is deprecated from the response","version":"7.6"},{"description":"The field \u0027ignoredConditions\u0027 is added to the response","version":"6.4"}],"params":[{"key":"analysisId","description":"Analysis id","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL1"},{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"projectId","description":"Project id. Doesn\u0027t work with branches or pull requests","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"}]},{"key":"rename","description":"Rename a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"ID of the quality gate to rename","required":true,"internal":false,"exampleValue":"1"},{"key":"name","description":"New name of the quality gate","required":true,"internal":false,"exampleValue":"My Quality Gate","maximumLength":100},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"search","description":"Search for projects associated (or not) to a quality gate.\u003cbr/\u003eOnly authorized projects for current user will be returned.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"New field \u0027paging\u0027 in response","version":"7.9"},{"description":"New field \u0027key\u0027 returning the project key in \u0027results\u0027 response","version":"7.9"},{"description":"Field \u0027more\u0027 is deprecated in the response","version":"7.9"}],"params":[{"key":"gateId","description":"Quality Gate ID","required":true,"internal":false,"exampleValue":"1"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"page","description":"Page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"2"},{"key":"pageSize","description":"Page size","required":false,"internal":false,"exampleValue":"10"},{"key":"query","description":"To search for projects containing this string. If this parameter is set, \"selected\" is set to \"all\".","required":false,"internal":false,"exampleValue":"abc"},{"key":"selected","description":"Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).","required":false,"internal":false,"defaultValue":"selected","possibleValues":["all","deselected","selected"]}]},{"key":"select","description":"Associate a project to a quality gate.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eProject id as a numeric value is deprecated since 6.1. Please use the id similar to \u0027AU-TpxcA-iU5OvuD2FLz\u0027.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"gateId","description":"Quality gate id","required":true,"internal":false,"exampleValue":"1"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"projectId","description":"Project id. Project id as an numeric value is deprecated since 6.1","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"projectKey","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"set_as_default","description":"Set a quality gate as the default quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"ID of the quality gate to set as default","required":true,"internal":false,"exampleValue":"1"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"show","description":"Display the details of a quality gate","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"\u0027period\u0027 and \u0027warning\u0027 fields of conditions are removed from the response","version":"7.6"},{"description":"\u0027isBuiltIn\u0027 field is added to the response","version":"7.0"},{"description":"\u0027actions\u0027 field is added in the response","version":"7.0"}],"params":[{"key":"id","description":"ID of the quality gate. Either id or name must be set","required":false,"internal":false,"exampleValue":"1"},{"key":"name","description":"Name of the quality gate. Either id or name must be set","required":false,"internal":false,"exampleValue":"My Quality Gate"},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"unset_default","description":"This webservice is no more available : a default quality gate is mandatory.","deprecatedSince":"7.0","internal":false,"post":true,"hasResponseExample":true,"changelog":[{"description":"Unset a quality gate is no more authorized","version":"7.0"}]},{"key":"update_condition","description":"Update a condition attached to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters","version":"7.6"},{"description":"Made \u0027error\u0027 parameter mandatory","version":"7.6"},{"description":"Reduced the possible values of \u0027op\u0027 parameter to LT and GT","version":"7.6"}],"params":[{"key":"error","description":"Condition error threshold","required":true,"internal":false,"exampleValue":"10","maximumLength":64},{"key":"id","description":"Condition ID","required":true,"internal":false,"exampleValue":"10"},{"key":"metric","description":"Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e","required":true,"internal":false,"exampleValue":"blocker_violations, vulnerabilities, new_code_smells"},{"key":"op","description":"Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"GT","possibleValues":["LT","GT"]},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]}]},{"path":"api/qualityprofiles","description":"Manage quality profiles.","actions":[{"key":"activate_rule","description":"Activate a rule on a Quality Profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedKey":"profile_key","deprecatedKeySince":"6.5"},{"key":"params","description":"Parameters as semi-colon list of \u003ccode\u003ekey\u003dvalue\u003c/code\u003e. Ignored if parameter reset is true.","required":false,"internal":false,"exampleValue":"params\u003dkey1\u003dv1;key2\u003dv2"},{"key":"reset","description":"Reset severity and parameters of activated rule. Set the values defined on parent profile or from rule default values.","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"rule","description":"Rule key","required":true,"internal":false,"exampleValue":"squid:AvoidCycles","deprecatedKey":"rule_key","deprecatedKeySince":"6.5"},{"key":"severity","description":"Severity. Ignored if parameter reset is true.","required":false,"internal":false,"possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]}]},{"key":"activate_rules","description":"Bulk-activate rules on one quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"activation","description":"Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"active_severities","description":"Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"available_since","description":"Filters rules added since date. Format is yyyy-MM-dd","required":false,"internal":false,"exampleValue":"2014-06-22"},{"key":"cwe","description":"Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.","required":false,"internal":false,"exampleValue":"12,125,unknown"},{"key":"inheritance","description":"Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"INHERITED,OVERRIDES","possibleValues":["NONE","INHERITED","OVERRIDES"]},{"key":"is_template","description":"Filter template rules","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"languages","description":"Comma-separated list of languages","required":false,"internal":false,"exampleValue":"java,js"},{"key":"organization","description":"Organization key","required":false,"internal":false,"exampleValue":"my-org"},{"key":"owaspTop10","description":"Comma-separated list of OWASP Top 10 lowercase categories.","required":false,"internal":false,"possibleValues":["a1","a2","a3","a4","a5","a6","a7","a8","a9","a10"]},{"key":"q","description":"UTF-8 search query","required":false,"internal":false,"exampleValue":"xpath","minimumLength":2},{"key":"qprofile","description":"Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"repositories","description":"Comma-separated list of repositories","required":false,"internal":false,"exampleValue":"checkstyle,findbugs"},{"key":"rule_key","description":"Key of rule to search for","required":false,"internal":false,"exampleValue":"squid:S001"},{"key":"s","description":"Sort field","required":false,"internal":false,"exampleValue":"name","possibleValues":["name","updatedAt","createdAt","key"]},{"key":"sansTop25","description":"Comma-separated list of SANS Top 25 categories.","required":false,"internal":false,"possibleValues":["insecure-interaction","risky-resource","porous-defenses"]},{"key":"severities","description":"Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"sonarsourceSecurity","description":"Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category","required":false,"internal":false,"exampleValue":"sql-injection,command-injection,others","possibleValues":["sql-injection","command-injection","path-traversal-injection","ldap-injection","xpath-injection","rce","dos","ssrf","csrf","xss","log-injection","http-response-splitting","open-redirect","xxe","object-injection","weak-cryptography","auth","insecure-conf","encrypt-data","traceability","file-manipulation","others"]},{"key":"statuses","description":"Comma-separated list of status codes","required":false,"internal":false,"exampleValue":"READY","possibleValues":["BETA","DEPRECATED","READY","REMOVED"]},{"key":"tags","description":"Comma-separated list of tags. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"security,java8"},{"key":"targetKey","description":"Quality Profile key on which the rule activation is done. To retrieve a quality profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL0","deprecatedKey":"profile_key","deprecatedKeySince":"6.5"},{"key":"targetSeverity","description":"Severity to set on the activated rules","required":false,"internal":false,"deprecatedKey":"activation_severity","deprecatedKeySince":"6.5","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"template_key","description":"Key of the template rule to filter on. Used to search for the custom rules based on this template.","required":false,"internal":false,"exampleValue":"java:S001"},{"key":"types","description":"Comma-separated list of types. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"BUG","possibleValues":["CODE_SMELL","BUG","VULNERABILITY","SECURITY_HOTSPOT"]}]},{"key":"add_project","description":"Associate a project with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"projectKey","deprecatedKeySince":"6.5"},{"key":"projectUuid","description":"Project ID. Either this parameter or \u0027project\u0027 must be set.","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL5","deprecatedSince":"6.5"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"backup","description":"Backup a quality profile in XML form. The exported profile can be restored through api/qualityprofiles/restore.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"change_parent","description":"Change a quality profile\u0027s parent.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"parentKey","description":"New parent profile key.\u003cbr\u003e If no profile is provided, the inheritance link with current parent profile (if any) is broken, which deactivates all rules which come from the parent and are not overridden.","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FLz","deprecatedSince":"6.6"},{"key":"parentQualityProfile","description":"Quality profile name. If this parameter is set, \u0027parentKey\u0027 must not be set and \u0027language\u0027 must be set to disambiguate.","required":false,"internal":false,"exampleValue":"Sonar way"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"changelog","description":"Get the history of changes on a quality profile: rule activation/deactivation, change in parameters/severity. Events are ordered by date in descending order (most recent first).","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"50","exampleValue":"20","maximumValue":500},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"},{"key":"since","description":"Start date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"},{"key":"to","description":"End date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.","required":false,"internal":false,"exampleValue":"2017-10-19 or 2017-10-19T13:00:00+0200"}]},{"key":"copy","description":"Copy a quality profile.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"fromKey","description":"Quality profile key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"toName","description":"Name for the new quality profile.","required":true,"internal":false,"exampleValue":"My Sonar way"}]},{"key":"create","description":"Create a quality profile.\u003cbr\u003eRequires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"language","description":"Quality profile language","required":true,"internal":false,"exampleValue":"js","possibleValues":["abap","apex","c","cloudformation","cobol","cpp","cs","css","flex","go","java","js","json","jsp","kotlin","objc","php","plsql","py","ruby","scala","swift","terraform","ts","tsql","vbnet","web","xml","yaml"]},{"key":"name","description":"Quality profile name","required":true,"internal":false,"exampleValue":"My Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6","maximumLength":100},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"deactivate_rule","description":"Deactivate a rule on a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedKey":"profile_key","deprecatedKeySince":"6.5"},{"key":"rule","description":"Rule key","required":true,"internal":false,"exampleValue":"squid:AvoidCycles","deprecatedKey":"rule_key","deprecatedKeySince":"6.5"}]},{"key":"deactivate_rules","description":"Bulk deactivate rules on Quality profiles.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"activation","description":"Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"active_severities","description":"Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"available_since","description":"Filters rules added since date. Format is yyyy-MM-dd","required":false,"internal":false,"exampleValue":"2014-06-22"},{"key":"cwe","description":"Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.","required":false,"internal":false,"exampleValue":"12,125,unknown"},{"key":"inheritance","description":"Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"INHERITED,OVERRIDES","possibleValues":["NONE","INHERITED","OVERRIDES"]},{"key":"is_template","description":"Filter template rules","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"languages","description":"Comma-separated list of languages","required":false,"internal":false,"exampleValue":"java,js"},{"key":"organization","description":"Organization key","required":false,"internal":false,"exampleValue":"my-org"},{"key":"owaspTop10","description":"Comma-separated list of OWASP Top 10 lowercase categories.","required":false,"internal":false,"possibleValues":["a1","a2","a3","a4","a5","a6","a7","a8","a9","a10"]},{"key":"q","description":"UTF-8 search query","required":false,"internal":false,"exampleValue":"xpath","minimumLength":2},{"key":"qprofile","description":"Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"repositories","description":"Comma-separated list of repositories","required":false,"internal":false,"exampleValue":"checkstyle,findbugs"},{"key":"rule_key","description":"Key of rule to search for","required":false,"internal":false,"exampleValue":"squid:S001"},{"key":"s","description":"Sort field","required":false,"internal":false,"exampleValue":"name","possibleValues":["name","updatedAt","createdAt","key"]},{"key":"sansTop25","description":"Comma-separated list of SANS Top 25 categories.","required":false,"internal":false,"possibleValues":["insecure-interaction","risky-resource","porous-defenses"]},{"key":"severities","description":"Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"sonarsourceSecurity","description":"Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category","required":false,"internal":false,"exampleValue":"sql-injection,command-injection,others","possibleValues":["sql-injection","command-injection","path-traversal-injection","ldap-injection","xpath-injection","rce","dos","ssrf","csrf","xss","log-injection","http-response-splitting","open-redirect","xxe","object-injection","weak-cryptography","auth","insecure-conf","encrypt-data","traceability","file-manipulation","others"]},{"key":"statuses","description":"Comma-separated list of status codes","required":false,"internal":false,"exampleValue":"READY","possibleValues":["BETA","DEPRECATED","READY","REMOVED"]},{"key":"tags","description":"Comma-separated list of tags. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"security,java8"},{"key":"targetKey","description":"Quality Profile key on which the rule deactivation is done. To retrieve a profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL1","deprecatedKey":"profile_key","deprecatedKeySince":"6.5"},{"key":"template_key","description":"Key of the template rule to filter on. Used to search for the custom rules based on this template.","required":false,"internal":false,"exampleValue":"java:S001"},{"key":"types","description":"Comma-separated list of types. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"BUG","possibleValues":["CODE_SMELL","BUG","VULNERABILITY","SECURITY_HOTSPOT"]}]},{"key":"delete","description":"Delete a quality profile and all its descendants. The default quality profile cannot be deleted.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"export","description":"Export a quality profile.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"exporterKey","description":"Output format. If left empty, the same format as api/qualityprofiles/backup is used. Possible values are described by api/qualityprofiles/exporters.","required":false,"internal":false,"deprecatedKey":"format","deprecatedKeySince":"6.3","possibleValues":["sonarlint-vs-vbnet","sonarlint-vs-cs","roslyn-vbnet","roslyn-cs"]},{"key":"key","description":"Quality profile key","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6"},{"key":"language","description":"Quality profile language","required":false,"internal":false,"exampleValue":"terraform","possibleValues":["abap","apex","c","cloudformation","cobol","cpp","cs","css","flex","go","java","js","json","jsp","kotlin","objc","php","plsql","py","ruby","scala","swift","terraform","ts","tsql","vbnet","web","xml","yaml"]},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"qualityProfile","description":"Quality profile name to export. If left empty, the default profile for the language is exported.","required":false,"internal":false,"exampleValue":"My Sonar way","deprecatedKey":"name","deprecatedKeySince":"6.6"}]},{"key":"exporters","description":"Lists available profile export formats.","internal":false,"post":false,"hasResponseExample":true,"changelog":[]},{"key":"importers","description":"List supported importers.","internal":false,"post":false,"hasResponseExample":true,"changelog":[]},{"key":"inheritance","description":"Show a quality profile\u0027s ancestors and children.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"projects","description":"List projects with their association status regarding a quality profile","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"\u0027more\u0027 response field is deprecated","version":"7.2"},{"description":"\u0027id\u0027 response field is deprecated","version":"6.5"},{"description":"\u0027uuid\u0027 response field is deprecated and replaced by \u0027id\u0027","version":"6.0"},{"description":"\u0027key\u0027 response field has been added to return the project key","version":"6.0"}],"params":[{"key":"key","description":"Quality profile key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42","deprecatedKey":"page","deprecatedKeySince":"6.5"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"q","description":"Limit search to projects that contain the supplied string.","required":false,"internal":false,"exampleValue":"sonar","deprecatedKey":"query","deprecatedKeySince":"6.5"},{"key":"selected","description":"Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).","required":false,"internal":false,"defaultValue":"selected","possibleValues":["all","deselected","selected"]}]},{"key":"remove_project","description":"Remove a project\u0027s association with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"projectKey","deprecatedKeySince":"6.5"},{"key":"projectUuid","description":"Project ID. Either this parameter, or \u0027project\u0027 must be set.","required":false,"internal":false,"exampleValue":"AU-TpxcB-iU5OvuD2FL6","deprecatedSince":"6.5"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"rename","description":"Rename a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key","required":true,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"name","description":"New quality profile name","required":true,"internal":false,"exampleValue":"My Sonar way","maximumLength":100}]},{"key":"restore","description":"Restore a quality profile using an XML file. The restored profile name is taken from the backup file, so if a profile with the same name and language already exists, it will be overwritten.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"backup","description":"A profile backup file in XML format, as generated by api/qualityprofiles/backup or the former api/profiles/backup.","required":true,"internal":false},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"restore_built_in","description":"This web service has no effect since 6.4. It\u0027s no more possible to restore built-in quality profiles because they are automatically updated and read only. Returns HTTP code 410.","deprecatedSince":"6.4","internal":false,"post":true,"hasResponseExample":false,"changelog":[]},{"key":"search","description":"Search quality profiles","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Add available actions \u0027delete\u0027 and \u0027associateProjects\u0027","version":"7.0"},{"description":"Add available actions \u0027edit\u0027, \u0027copy\u0027 and \u0027setAsDefault\u0027 and global action \u0027create\u0027","version":"6.6"},{"description":"The parameters \u0027defaults\u0027, \u0027project\u0027 and \u0027language\u0027 can be combined without any constraint","version":"6.5"}],"params":[{"key":"defaults","description":"If set to true, return only the quality profiles marked as default for each language","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"language","description":"Language key. If provided, only profiles for the given language are returned.","required":false,"internal":false,"possibleValues":["abap","apex","c","cloudformation","cobol","cpp","cs","css","flex","go","java","js","json","jsp","kotlin","objc","php","plsql","py","ruby","scala","swift","terraform","ts","tsql","vbnet","web","xml","yaml"]},{"key":"organization","description":"Organization key.","required":true,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"projectKey","deprecatedKeySince":"6.5"},{"key":"qualityProfile","description":"Quality profile name","required":false,"internal":false,"exampleValue":"SonarQube Way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]},{"key":"set_default","description":"Select the default profile for a given language.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"key","description":"Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy","deprecatedSince":"6.6","deprecatedKey":"profileKey","deprecatedKeySince":"6.5"},{"key":"language","description":"Quality profile language. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"possibleValues":["css","scala","jsp","py","js","plsql","apex","java","web","xml","flex","json","vbnet","cloudformation","swift","yaml","cpp","c","go","kotlin","tsql","ruby","cs","cobol","php","terraform","abap","objc","ts"]},{"key":"organization","description":"Organization key.","required":false,"internal":false,"exampleValue":"my-org"},{"key":"qualityProfile","description":"Quality profile name. Mandatory if \u0027key\u0027 is not set.","required":false,"internal":false,"exampleValue":"Sonar way","deprecatedKey":"profileName","deprecatedKeySince":"6.6"}]}]},{"path":"api/rules","description":"Get and update some details of automatic rules, and manage custom rules.","actions":[{"key":"repositories","description":"List available rule repositories","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"language","description":"A language key; if provided, only repositories for the given language will be returned","required":false,"internal":false,"exampleValue":"java"},{"key":"q","description":"A pattern to match repository keys/names against","required":false,"internal":false,"exampleValue":"squid"}]},{"key":"search","description":"Search for a collection of relevant rules matching a specified query.\u003cbr/\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The field \u0027updatedAt\u0027 has been added to the \u0027f\u0027 parameter","version":"7.5"}],"params":[{"key":"activation","description":"Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"active_severities","description":"Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"asc","description":"Ascending sort","required":false,"internal":false,"defaultValue":"true","possibleValues":["true","false","yes","no"]},{"key":"available_since","description":"Filters rules added since date. Format is yyyy-MM-dd","required":false,"internal":false,"exampleValue":"2014-06-22"},{"key":"cwe","description":"Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.","required":false,"internal":false,"exampleValue":"12,125,unknown"},{"key":"f","description":"Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :\u003cul\u003e\u003cli\u003e\"defaultDebtRemFn\" becomes \"defaultRemFn\"\u003c/li\u003e\u003cli\u003e\"debtRemFn\" becomes \"remFn\"\u003c/li\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e","required":false,"internal":false,"exampleValue":"repo,name","possibleValues":["actives","createdAt","debtOverloaded","debtRemFn","defaultDebtRemFn","defaultRemFn","deprecatedKeys","effortToFixDescription","gapDescription","htmlDesc","htmlNote","internalKey","isExternal","isTemplate","lang","langName","mdDesc","mdNote","name","noteLogin","params","remFn","remFnOverloaded","repo","scope","severity","status","sysTags","tags","templateKey","updatedAt"]},{"key":"facets","description":"Comma-separated list of the facets to be computed. No facet is computed by default.","required":false,"internal":false,"exampleValue":"languages,repositories","possibleValues":["languages","repositories","tags","severities","active_severities","statuses","types","true","cwe","owaspTop10","sansTop25","sonarsourceSecurity"]},{"key":"include_external","description":"Include external engine rules in the results","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"inheritance","description":"Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"INHERITED,OVERRIDES","possibleValues":["NONE","INHERITED","OVERRIDES"]},{"key":"is_template","description":"Filter template rules","required":false,"internal":false,"possibleValues":["true","false","yes","no"]},{"key":"languages","description":"Comma-separated list of languages","required":false,"internal":false,"exampleValue":"java,js"},{"key":"organization","description":"Organization key","required":false,"internal":false,"exampleValue":"my-org"},{"key":"owaspTop10","description":"Comma-separated list of OWASP Top 10 lowercase categories.","required":false,"internal":false,"possibleValues":["a1","a2","a3","a4","a5","a6","a7","a8","a9","a10"]},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"q","description":"UTF-8 search query","required":false,"internal":false,"exampleValue":"xpath","minimumLength":2},{"key":"qprofile","description":"Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"repositories","description":"Comma-separated list of repositories","required":false,"internal":false,"exampleValue":"checkstyle,findbugs"},{"key":"rule_key","description":"Key of rule to search for","required":false,"internal":false,"exampleValue":"squid:S001"},{"key":"rule_keys","description":"Rule keys","required":false,"internal":false,"exampleValue":"squid:S1002,squid:S1003"},{"key":"s","description":"Sort field","required":false,"internal":false,"exampleValue":"name","possibleValues":["name","updatedAt","createdAt","key"]},{"key":"sansTop25","description":"Comma-separated list of SANS Top 25 categories.","required":false,"internal":false,"possibleValues":["insecure-interaction","risky-resource","porous-defenses"]},{"key":"severities","description":"Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.","required":false,"internal":false,"exampleValue":"CRITICAL,BLOCKER","possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"sonarsourceSecurity","description":"Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category","required":false,"internal":false,"exampleValue":"sql-injection,command-injection,others","possibleValues":["sql-injection","command-injection","path-traversal-injection","ldap-injection","xpath-injection","rce","dos","ssrf","csrf","xss","log-injection","http-response-splitting","open-redirect","xxe","object-injection","weak-cryptography","auth","insecure-conf","encrypt-data","traceability","file-manipulation","others"]},{"key":"statuses","description":"Comma-separated list of status codes","required":false,"internal":false,"exampleValue":"READY","possibleValues":["BETA","DEPRECATED","READY","REMOVED"]},{"key":"tags","description":"Comma-separated list of tags. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"security,java8"},{"key":"template_key","description":"Key of the template rule to filter on. Used to search for the custom rules based on this template.","required":false,"internal":false,"exampleValue":"java:S001"},{"key":"types","description":"Comma-separated list of types. Returned rules match any of the tags (OR operator)","required":false,"internal":false,"exampleValue":"BUG","possibleValues":["CODE_SMELL","BUG","VULNERABILITY","SECURITY_HOTSPOT"]}]},{"key":"show","description":"Get detailed information about a rule\u003cbr\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003eIn 7.1, the field \u0027scope\u0027 has been added.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"actives","description":"Show rule\u0027s activations for all profiles (\"active rules\")","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"key","description":"Rule key","required":true,"internal":false,"exampleValue":"javascript:EmptyBlock"},{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"tags","description":"List rule tags","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 100","required":false,"internal":false,"defaultValue":"10","exampleValue":"20","maximumValue":100},{"key":"q","description":"Limit search to tags that contain the supplied string.","required":false,"internal":false,"exampleValue":"misra"}]},{"key":"update","description":"Update an existing rule.\u003cbr\u003eRequires the \u0027Administer Quality Profiles\u0027 permission","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"debt_sub_characteristic","description":"Debt characteristics are no more supported. This parameter is ignored.","required":false,"internal":false,"deprecatedSince":"5.5"},{"key":"key","description":"Key of the rule to update","required":true,"internal":false,"exampleValue":"javascript:NullCheck","maximumLength":200},{"key":"markdown_description","description":"Rule description (mandatory for custom rule and manual rule)","required":false,"internal":false,"exampleValue":"Description of my custom rule"},{"key":"markdown_note","description":"Optional note in markdown format. Use empty value to remove current note. Note is not changed if the parameter is not set.","required":false,"internal":false,"exampleValue":"my *note*"},{"key":"name","description":"Rule name (mandatory for custom rule)","required":false,"internal":false,"exampleValue":"My custom rule","maximumLength":200},{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"params","description":"Parameters as semi-colon list of \u003ckey\u003e\u003d\u003cvalue\u003e, for example \u0027params\u003dkey1\u003dv1;key2\u003dv2\u0027 (Only when updating a custom rule)","required":false,"internal":false},{"key":"remediation_fn_base_effort","description":"Base effort of the remediation function of the rule","required":false,"internal":false,"exampleValue":"1d"},{"key":"remediation_fn_type","description":"Type of the remediation function of the rule","required":false,"internal":false,"possibleValues":["LINEAR","LINEAR_OFFSET","CONSTANT_ISSUE"]},{"key":"remediation_fy_gap_multiplier","description":"Gap multiplier of the remediation function of the rule","required":false,"internal":false,"exampleValue":"3min"},{"key":"severity","description":"Rule severity (Only when updating a custom rule)","required":false,"internal":false,"possibleValues":["INFO","MINOR","MAJOR","CRITICAL","BLOCKER"]},{"key":"status","description":"Rule status (Only when updating a custom rule)","required":false,"internal":false,"possibleValues":["BETA","DEPRECATED","READY","REMOVED"]},{"key":"tags","description":"Optional comma-separated list of tags to set. Use blank value to remove current tags. Tags are not changed if the parameter is not set.","required":false,"internal":false,"exampleValue":"java8,security"}]}]},{"path":"api/settings","description":"Manage settings.","actions":[{"key":"list_definitions","description":"List settings definitions.\u003cbr\u003eRequires \u0027Browse\u0027 permission when a component is specified\u003cbr/\u003eTo access licensed settings, authentication is required\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"}],"params":[{"key":"component","description":"Component key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"reset","description":"Remove a setting value.\u003cbr\u003eThe settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"},{"description":"The settings defined in conf/sonar.properties are read-only and can\u0027t be changed","version":"7.1"}],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"component","description":"Component key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"componentKey","deprecatedKeySince":"6.3"},{"key":"keys","description":"Comma-separated list of keys","required":true,"internal":false,"exampleValue":"sonar.links.scm,sonar.debt.hoursInDay"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"}]},{"key":"set","description":"Update a setting value.\u003cbr\u003eEither \u0027value\u0027 or \u0027values\u0027 must be provided.\u003cbr\u003e The settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"},{"description":"The settings defined in conf/sonar.properties are read-only and can\u0027t be changed","version":"7.1"}],"params":[{"key":"component","description":"Component key","required":false,"internal":false,"exampleValue":"my_project","deprecatedKey":"componentKey","deprecatedKeySince":"6.3"},{"key":"fieldValues","description":"Setting field values. To set several values, the parameter must be called once for each value.","required":false,"internal":false,"exampleValue":"fieldValues\u003d{\"firstField\":\"first value\", \"secondField\":\"second value\", \"thirdField\":\"third value\"}"},{"key":"key","description":"Setting key","required":true,"internal":false,"exampleValue":"sonar.links.scm"},{"key":"value","description":"Setting value. To reset a value, please use the reset web service.","required":false,"internal":false,"exampleValue":"git@github.com:SonarSource/sonarqube.git","maximumLength":4000},{"key":"values","description":"Setting multi value. To set several values, the parameter must be called once for each value.","required":false,"internal":false,"exampleValue":"values\u003dfirstValue\u0026values\u003dsecondValue\u0026values\u003dthirdValue"}]},{"key":"values","description":"List settings values.\u003cbr\u003eIf no value has been set for a setting, then the default value is returned.\u003cbr\u003eThe settings from conf/sonar.properties are excluded from results.\u003cbr\u003eRequires \u0027Browse\u0027 or \u0027Execute Analysis\u0027 permission when a component is specified.\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"The use of module keys in parameter \u0027component\u0027 is deprecated","version":"7.6"},{"description":"The settings from conf/sonar.properties are excluded from results.","version":"7.1"}],"params":[{"key":"component","description":"Component key","required":false,"internal":false,"exampleValue":"my_project"},{"key":"keys","description":"List of setting keys","required":false,"internal":false,"exampleValue":"sonar.test.inclusions,sonar.exclusions"}]}]},{"path":"api/sources","description":"Get details on source files. See also api/tests.","actions":[{"key":"raw","description":"Get source code as raw text. Require \u0027See Source Code\u0027 permission on file","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"branch","description":"Branch key","required":false,"internal":false,"exampleValue":"feature/my_branch"},{"key":"key","description":"File key","required":true,"internal":false,"exampleValue":"my_project:src/foo/Bar.php"},{"key":"pullRequest","description":"Pull request id","required":false,"internal":false,"exampleValue":"5461"}]},{"key":"scm","description":"Get SCM information of source files. Require See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eAuthor of the commit\u003c/li\u003e\u003cli\u003eDatetime of the commit (before 5.2 it was only the Date)\u003c/li\u003e\u003cli\u003eRevision of the commit (added in 5.2)\u003c/li\u003e\u003c/ol\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"commits_by_line","description":"Group lines by SCM commit if value is false, else display commits for each line, even if two consecutive lines relate to the same commit.","required":false,"internal":false,"defaultValue":"false","possibleValues":["true","false","yes","no"]},{"key":"from","description":"First line to return. Starts at 1","required":false,"internal":false,"defaultValue":"1","exampleValue":"10"},{"key":"key","description":"File key","required":true,"internal":false,"exampleValue":"my_project:/src/foo/Bar.php"},{"key":"to","description":"Last line to return (inclusive)","required":false,"internal":false,"exampleValue":"20"}]},{"key":"show","description":"Get source code. Requires See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eContent of the line\u003c/li\u003e\u003c/ol\u003e","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"from","description":"First line to return. Starts at 1","required":false,"internal":false,"defaultValue":"1","exampleValue":"10"},{"key":"key","description":"File key","required":true,"internal":false,"exampleValue":"my_project:/src/foo/Bar.php"},{"key":"to","description":"Last line to return (inclusive)","required":false,"internal":false,"exampleValue":"20"}]}]},{"path":"api/timemachine","description":"Removed since 6.3, please use api/measures/search_history instead","actions":[{"key":"index","description":"The web service is removed and you\u0027re invited to use api/measures/search_history instead","deprecatedSince":"6.3","internal":false,"post":false,"hasResponseExample":true,"changelog":[]}]},{"path":"api/user_groups","description":"Manage user groups.","actions":[{"key":"add_user","description":"Add a user to a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"It\u0027s no longer possible to add a user to the default group","version":"6.4"}],"params":[{"key":"id","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"login","description":"User login","required":false,"internal":false,"exampleValue":"g.hopper"},{"key":"name","description":"Group name","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization","required":false,"internal":false,"exampleValue":"my-org"}]},{"key":"create","description":"Create a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"description","description":"Description for the new group. A group description cannot be larger than 200 characters.","required":false,"internal":false,"exampleValue":"Default group for new users","maximumLength":200},{"key":"name","description":"Name for the new group. A group name cannot be larger than 255 characters and must be unique. The value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used.","required":true,"internal":false,"exampleValue":"sonar-users","maximumLength":255},{"key":"organization","description":"Key of organization","required":true,"internal":false,"exampleValue":"my-org"}]},{"key":"delete","description":"Delete a group. The default groups cannot be deleted.\u003cbr/\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"name","description":"Group name","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization","required":false,"internal":false,"exampleValue":"my-org"}]},{"key":"remove_user","description":"Remove a user from a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"id","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"login","description":"User login","required":false,"internal":false,"exampleValue":"g.hopper"},{"key":"name","description":"Group name","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization","required":false,"internal":false,"exampleValue":"my-org"}]},{"key":"search","description":"Search for user groups.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Paging response fields moved to a Paging object","version":"6.4"},{"description":"\u0027default\u0027 response field has been added","version":"6.4"}],"params":[{"key":"f","description":"Comma-separated list of the fields to be returned in response. All the fields are returned by default.","required":false,"internal":false,"possibleValues":["name","description","membersCount"]},{"key":"organization","description":"Key of organization","required":true,"internal":false,"exampleValue":"my-org"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"100","exampleValue":"20","maximumValue":500},{"key":"q","description":"Limit search to names that contain the supplied string.","required":false,"internal":false,"exampleValue":"sonar-users"}]},{"key":"update","description":"Update a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":true,"hasResponseExample":false,"changelog":[{"description":"The default group is no longer editable","version":"6.4"}],"params":[{"key":"description","description":"New optional description for the group. A group description cannot be larger than 200 characters. If value is not defined, then description is not changed.","required":false,"internal":false,"exampleValue":"Default group for new users","maximumLength":200},{"key":"id","description":"Identifier of the group.","required":true,"internal":false,"exampleValue":"42"},{"key":"name","description":"New optional name for the group. A group name cannot be larger than 255 characters and must be unique. Value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used. If value is empty or not defined, then name is not changed.","required":false,"internal":false,"exampleValue":"my-group","maximumLength":255}]},{"key":"users","description":"Search for users with membership information with respect to a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"id","description":"Group id","required":false,"internal":false,"exampleValue":"42"},{"key":"name","description":"Group name","required":false,"internal":false,"exampleValue":"sonar-administrators"},{"key":"organization","description":"Key of organization","required":false,"internal":false,"exampleValue":"my-org"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0.","required":false,"internal":false,"defaultValue":"25","exampleValue":"20"},{"key":"q","description":"Limit search to names or logins that contain the supplied string.","required":false,"internal":false,"exampleValue":"freddy"},{"key":"selected","description":"Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).","required":false,"internal":false,"defaultValue":"selected","possibleValues":["all","deselected","selected"]}]}]},{"path":"api/user_properties","description":"Removed since 6.3, please use api/favorites and api/notifications instead","actions":[{"key":"index","description":"This web service is removed","deprecatedSince":"6.3","internal":false,"post":false,"hasResponseExample":true,"changelog":[]}]},{"path":"api/user_tokens","description":"List, create, and delete a user\u0027s access tokens.","actions":[{"key":"generate","description":"Generate a user access token. \u003cbr /\u003ePlease keep your tokens secret. They enable to authenticate and analyze projects.\u003cbr /\u003eIt requires administration permissions to specify a \u0027login\u0027 and generate a token for another user. Otherwise, a token is generated for the current user.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"login","description":"User login. If not set, the token is generated for the authenticated user.","required":false,"internal":false,"exampleValue":"g.hopper"},{"key":"name","description":"Token name","required":true,"internal":false,"exampleValue":"Project scan on Travis","maximumLength":100}]},{"key":"revoke","description":"Revoke a user access token. \u003cbr/\u003eIt requires administration permissions to specify a \u0027login\u0027 and revoke a token for another user. Otherwise, the token for the current user is revoked.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"login","description":"User login","required":false,"internal":false,"exampleValue":"g.hopper"},{"key":"name","description":"Token name","required":true,"internal":false,"exampleValue":"Project scan on Travis"}]},{"key":"search","description":"List the access tokens of a user.\u003cbr\u003eThe login must exist and active.\u003cbr\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user is using a token many times in less than one hour.\u003cbr/It requires administration permissions to specify a \u0027login\u0027 and list the tokens of another user. Otherwise, tokens for the current user are listed.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"New field \u0027lastConnectionDate\u0027 is added to response","version":"7.7"}],"params":[{"key":"login","description":"User login","required":false,"internal":false,"exampleValue":"g.hopper"}]}]},{"path":"api/users","description":"Manage users.","actions":[{"key":"groups","description":"Lists the groups a user belongs to. \u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the organization.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Paging response fields moved to a Paging object","version":"6.4"},{"description":"\u0027default\u0027 response field has been added","version":"6.4"}],"params":[{"key":"login","description":"A user login","required":true,"internal":false,"exampleValue":"admin"},{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0.","required":false,"internal":false,"defaultValue":"25","exampleValue":"20"},{"key":"q","description":"Limit search to group names that contain the supplied string.","required":false,"internal":false,"exampleValue":"users"},{"key":"selected","description":"Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).","required":false,"internal":false,"defaultValue":"selected","possibleValues":["all","deselected","selected"]}]},{"key":"search","description":"Get a list of active users. \u003cbr/\u003eThe following fields are only returned when user has Administer System permission or for logged-in in user :\u003cul\u003e   \u003cli\u003e\u0027email\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalIdentity\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalProvider\u0027\u003c/li\u003e   \u003cli\u003e\u0027groups\u0027\u003c/li\u003e   \u003cli\u003e\u0027lastConnectionDate\u0027\u003c/li\u003e   \u003cli\u003e\u0027tokensCount\u0027\u003c/li\u003e\u003c/ul\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"New field \u0027lastConnectionDate\u0027 is added to response","version":"7.7"},{"description":"External identity is only returned to system administrators","version":"7.4"},{"description":"Paging response fields moved to a Paging object","version":"6.4"},{"description":"Avatar has been added to the response","version":"6.4"},{"description":"Email is only returned when user has Administer System permission","version":"6.4"}],"params":[{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less or equal than 500","required":false,"internal":false,"defaultValue":"50","exampleValue":"20","maximumValue":500},{"key":"q","description":"Filter on login, name and email","required":false,"internal":false,"minimumLength":2}]}]},{"path":"api/webhooks","description":"Webhooks allow to notify external services when a project analysis is done","actions":[{"key":"create","description":"Create a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.","internal":false,"post":true,"hasResponseExample":true,"changelog":[],"params":[{"key":"name","description":"Name displayed in the administration console of webhooks","required":true,"internal":false,"exampleValue":"My Webhook","maximumLength":100},{"key":"organization","description":"The key of the organization that will own the webhook","required":true,"internal":false,"exampleValue":"my-org","maximumLength":255},{"key":"project","description":"The key of the project that will own the webhook","required":false,"internal":false,"exampleValue":"my_project","maximumLength":100},{"key":"secret","description":"If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header","required":false,"internal":false,"exampleValue":"your_secret","maximumLength":200,"minimumLength":1},{"key":"url","description":"Server endpoint that will receive the webhook payload, for example \u0027http://my_server/foo\u0027. If HTTP Basic authentication is used, HTTPS is recommended to avoid man in the middle attacks. Example: \u0027https://myLogin:myPassword@my_server/foo\u0027","required":true,"internal":false,"exampleValue":"https://www.google.com/sonar","maximumLength":512}]},{"key":"delete","description":"Delete a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"webhook","description":"The key of the webhook to be deleted, auto-generated value can be obtained through api/webhooks/create or api/webhooks/list","required":true,"internal":false,"exampleValue":"my_project","maximumLength":40}]},{"key":"deliveries","description":"Get the recent deliveries for a specified project or Compute Engine task.\u003cbr/\u003eRequire \u0027Administer\u0027 permission on the related project.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"ceTaskId","description":"Id of the Compute Engine task","required":false,"internal":false,"exampleValue":"AU-Tpxb--iU5OvuD2FLy"},{"key":"componentKey","description":"Key of the project","required":false,"internal":false,"exampleValue":"my-project"},{"key":"p","description":"1-based page number","required":false,"internal":false,"defaultValue":"1","exampleValue":"42"},{"key":"ps","description":"Page size. Must be greater than 0 and less than 500","required":false,"internal":false,"defaultValue":"10","exampleValue":"20","maximumValue":500},{"key":"webhook","description":"Key of the webhook that triggered those deliveries, auto-generated value that can be obtained through api/webhooks/create or api/webhooks/list","required":false,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FLz"}]},{"key":"delivery","description":"Get a webhook delivery by its id.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"deliveryId","description":"Id of delivery","required":true,"internal":false,"exampleValue":"AU-TpxcA-iU5OvuD2FL3"}]},{"key":"list","description":"Search for global webhooks or project webhooks. Webhooks are ordered by name.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.","internal":false,"post":false,"hasResponseExample":true,"changelog":[{"description":"Field \u0027secret\u0027 added to response","version":"7.8"}],"params":[{"key":"organization","description":"Organization key","required":true,"internal":false,"exampleValue":"my-org"},{"key":"project","description":"Project key","required":false,"internal":false,"exampleValue":"my_project"}]},{"key":"update","description":"Update a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.","internal":false,"post":true,"hasResponseExample":false,"changelog":[],"params":[{"key":"name","description":"new name of the webhook","required":true,"internal":false,"exampleValue":"My Webhook","maximumLength":100},{"key":"secret","description":"If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header","required":false,"internal":false,"exampleValue":"your_secret","maximumLength":200,"minimumLength":1},{"key":"url","description":"new url to be called by the webhook","required":true,"internal":false,"exampleValue":"https://www.google.com/sonar","maximumLength":512},{"key":"webhook","description":"The key of the webhook to be updated, auto-generated value can be obtained through api/webhooks/create or api/webhooks/list","required":true,"internal":false,"exampleValue":"my_project","maximumLength":40}]}]},{"path":"api/webservices","description":"Get information on the web api supported on this instance.","actions":[{"key":"list","description":"List web services","internal":false,"post":false,"hasResponseExample":true,"changelog":[]},{"key":"response_example","description":"Display web service response example","internal":false,"post":false,"hasResponseExample":true,"changelog":[],"params":[{"key":"action","description":"Action of the web service","required":true,"internal":false,"exampleValue":"search"},{"key":"controller","description":"Controller of the web service","required":true,"internal":false,"exampleValue":"api/issues"}]}]}]}
+{
+    "webServices": [
+        {
+            "path": "api/authentication",
+            "description": "Handle authentication.",
+            "actions": [
+                {
+                    "key": "logout",
+                    "description": "Logout a user.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": []
+                },
+                {
+                    "key": "validate",
+                    "description": "Check credentials.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                }
+            ]
+        },
+        {
+            "path": "api/ce",
+            "description": "Get information on Compute Engine tasks.",
+            "actions": [
+                {
+                    "key": "activity",
+                    "description": "Search for tasks.\u003cbr\u003e Either componentId or component can be provided, but not both.\u003cbr\u003e Requires the project administration permission if componentId or component is set.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameters \u0027q\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "field \"pullRequest\" added",
+                            "version": "7.1"
+                        },
+                        {
+                            "description": "fields \"branch\" and \"branchType\" added",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "field \"logs\" is deprecated and its value is always false",
+                            "version": "6.1"
+                        },
+                        {
+                            "description": "it\u0027s no more possible to specify the page parameter.",
+                            "version": "5.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Key of the component (project) to filter on",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "projectKey"
+                        },
+                        {
+                            "key": "componentId",
+                            "description": "Id of the component (project) to filter on",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL0",
+                            "deprecatedSince": "8.0"
+                        },
+                        {
+                            "key": "maxExecutedAt",
+                            "description": "Maximum date of end of task processing (inclusive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "minSubmittedAt",
+                            "description": "Minimum date of task submission (inclusive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "onlyCurrents",
+                            "description": "Filter on the last tasks (only the most recent finished task by project)",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 1000",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 1000
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003cli\u003etask ids that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003eMust not be set together with componentId",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Apache"
+                        },
+                        {
+                            "key": "status",
+                            "description": "Comma separated list of task statuses",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "SUCCESS,FAILED,CANCELED",
+                            "exampleValue": "IN_PROGRESS,SUCCESS",
+                            "possibleValues": [
+                                "SUCCESS",
+                                "FAILED",
+                                "CANCELED",
+                                "PENDING",
+                                "IN_PROGRESS"
+                            ]
+                        },
+                        {
+                            "key": "type",
+                            "description": "Task type",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "REPORT",
+                            "possibleValues": [
+                                "REPORT"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "activity_status",
+                    "description": "Returns CE activity related metrics.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "New field \u0027pendingTime\u0027 in response, only included when there are pending tasks",
+                            "version": "7.8"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "componentId",
+                            "description": "Id of the component (project) to filter on",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL0"
+                        },
+                        {
+                            "key": "componentKey",
+                            "description": "Key of the component (project) to filter on",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedSince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "component",
+                    "description": "Get the pending tasks, in-progress tasks and the last executed task of a given component (usually a project).\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component.\u003cbr\u003eEither \u0027componentId\u0027 or \u0027component\u0027 must be provided.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \"component\" is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "fields \"branch\" and \"branchType\" added",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "field \"logs\" is deprecated and its value is always false",
+                            "version": "6.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "componentKey",
+                            "deprecatedKeySince": "6.6"
+                        },
+                        {
+                            "key": "componentId",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "task",
+                    "description": "Give Compute Engine task details such as type, status, duration and associated component.\u003cbr /\u003eRequires \u0027Execute Analysis\u0027 permission.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "fields \"branch\" and \"branchType\" added",
+                            "version": "6.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "additionalFields",
+                            "description": "Comma-separated list of the optional fields to be returned in response.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "scannerContext",
+                                "warnings"
+                            ]
+                        },
+                        {
+                            "key": "id",
+                            "description": "Id of task",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/components",
+            "description": "Get information about a component (file, directory, project, ...) and its ancestors or descendants. Update a project or module key.",
+            "actions": [
+                {
+                    "key": "search",
+                    "description": "Search for projects. Used to provide the ability to search for any component but this option has been removed and webservice \u0027api/components/tree\u0027 should be used instead for this purpose",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar"
+                        }
+                    ]
+                },
+                {
+                    "key": "show",
+                    "description": "Returns a component (file, directory, project) and its ancestors. The ancestors are ordered from the parent to the root project. Requires the following permission: \u0027Browse\u0027 on the project of the specified component.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        }
+                    ]
+                },
+                {
+                    "key": "tree",
+                    "description": "Navigate through components based on the chosen strategy.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of \u0027BRC\u0027 as value for parameter \u0027qualifiers\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Base component key. The search is based on this component.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "FILE_NAM",
+                            "minimumLength": 3
+                        },
+                        {
+                            "key": "qualifiers",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "BRC",
+                                "DIR",
+                                "FIL",
+                                "TRK",
+                                "UTS"
+                            ]
+                        },
+                        {
+                            "key": "s",
+                            "description": "Comma-separated list of sort fields",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "name",
+                            "exampleValue": "name, path",
+                            "possibleValues": [
+                                "name",
+                                "path",
+                                "qualifier"
+                            ]
+                        },
+                        {
+                            "key": "strategy",
+                            "description": "Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "all",
+                            "possibleValues": [
+                                "all",
+                                "children",
+                                "leaves"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/duplications",
+            "description": "Get duplication information for a project.",
+            "actions": [
+                {
+                    "key": "show",
+                    "description": "Get duplications. Require Browse permission on file\u0027s project",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The fields \u0027uuid\u0027, \u0027projectUuid\u0027, \u0027subProjectUuid\u0027 are deprecated in the response.",
+                            "version": "6.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "key",
+                            "description": "File key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project:/src/foo/Bar.php"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        },
+                        {
+                            "key": "uuid",
+                            "description": "File ID. If provided, \u0027key\u0027 must not be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "584a89f2-8037-4f7b-b82c-8b45d2d63fb2",
+                            "deprecatedSince": "6.5"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/favorites",
+            "description": "Manage user favorites",
+            "actions": [
+                {
+                    "key": "add",
+                    "description": "Add a project as favorite for the authenticated user.\u003cbr\u003eOnly 100 components can be added as favorite.\u003cbr\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "It\u0027s no longer possible to have more than 100 favorites by qualifier",
+                            "version": "7.7"
+                        },
+                        {
+                            "description": "It\u0027s no longer possible to set a directory as favorite",
+                            "version": "7.7"
+                        },
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Component key. Only components with qualifier TRK are supported",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project:/src/foo/Bar.php"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove",
+                    "description": "Remove a component (project, directory, file etc.) as favorite for the authenticated user.\u003cbr\u003eRequires authentication.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for the authenticated user favorites.\u003cbr\u003eRequires authentication.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/favourites",
+            "description": "Removed since 6.3, please use api/favorites instead",
+            "actions": [
+                {
+                    "key": "index",
+                    "description": "The web service is removed and you\u0027re invited to use api/favorites instead",
+                    "deprecatedSince": "6.3",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                }
+            ]
+        },
+        {
+            "path": "api/issues",
+            "description": "Read and update issues.",
+            "actions": [
+                {
+                    "key": "add_comment",
+                    "description": "Add a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response returns the issue with all its details",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "isFeedback",
+                            "description": "Define is the given comment is a feedback",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "exampleValue": "true"
+                        },
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "text",
+                            "description": "Comment text",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Won\u0027t fix because it doesn\u0027t apply to the context"
+                        }
+                    ]
+                },
+                {
+                    "key": "assign",
+                    "description": "Assign/Unassign an issue. Requires authentication and Browse permission on project",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "assignee",
+                            "description": "Login of the assignee. When not set, it will unassign the issue. Use \u0027_me\u0027 to assign to current user",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "admin"
+                        },
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        }
+                    ]
+                },
+                {
+                    "key": "authors",
+                    "description": "Search SCM accounts which match a given query.\u003cbr/\u003eRequires authentication.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The maximum size of \u0027ps\u0027 is set to 100",
+                            "version": "7.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 100",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "10",
+                            "exampleValue": "20",
+                            "maximumValue": 100
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to authors that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "luke"
+                        }
+                    ]
+                },
+                {
+                    "key": "bulk_change",
+                    "description": "Bulk change on issues.\u003cbr/\u003eRequires authentication.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "\u0027actions\u0027 parameter is ignored",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "add_tags",
+                            "description": "Add tags",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,java8",
+                            "deprecatedKey": "add_tags.tags",
+                            "deprecatedKeySince": "6.2"
+                        },
+                        {
+                            "key": "assign",
+                            "description": "To assign the list of issues to a specific user (login), or un-assign all the issues",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "john.smith",
+                            "deprecatedKey": "assign.assignee",
+                            "deprecatedKeySince": "6.2"
+                        },
+                        {
+                            "key": "comment",
+                            "description": "To add a comment to a list of issues",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Here is my comment"
+                        },
+                        {
+                            "key": "do_transition",
+                            "description": "Transition",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "reopen",
+                            "deprecatedKey": "do_transition.transition",
+                            "deprecatedKeySince": "6.2",
+                            "possibleValues": [
+                                "confirm",
+                                "unconfirm",
+                                "reopen",
+                                "resolve",
+                                "falsepositive",
+                                "wontfix",
+                                "close",
+                                "setinreview",
+                                "resolveasreviewed",
+                                "resetastoreview"
+                            ]
+                        },
+                        {
+                            "key": "issues",
+                            "description": "Comma-separated list of issue keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy,AU-TpxcA-iU5OvuD2FLz"
+                        },
+                        {
+                            "key": "remove_tags",
+                            "description": "Remove tags",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,java8",
+                            "deprecatedKey": "remove_tags.tags",
+                            "deprecatedKeySince": "6.2"
+                        },
+                        {
+                            "key": "sendNotifications",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "set_severity",
+                            "description": "To change the severity of the list of issues",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BLOCKER",
+                            "deprecatedKey": "set_severity.severity",
+                            "deprecatedKeySince": "6.2",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "set_type",
+                            "description": "To change the type of the list of issues",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BUG",
+                            "deprecatedKey": "set_type.type",
+                            "deprecatedKeySince": "6.2",
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY",
+                                "SECURITY_HOTSPOT"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "changelog",
+                    "description": "Display changelog of an issue.\u003cbr/\u003eRequires the \u0027Browse\u0027 permission on the project of the specified issue.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "changes on effort is expressed with the raw value in minutes (instead of the duration previously)",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        }
+                    ]
+                },
+                {
+                    "key": "delete_comment",
+                    "description": "Delete a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response returns the issue with all its details",
+                            "version": "6.3"
+                        },
+                        {
+                            "description": "the \u0027key\u0027 parameter is renamed \u0027comment\u0027",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "comment",
+                            "description": "Comment key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedKey": "key",
+                            "deprecatedKeySince": "6.3"
+                        }
+                    ]
+                },
+                {
+                    "key": "do_transition",
+                    "description": "Do workflow transition on an issue. Requires authentication and Browse permission on project.\u003cbr/\u003eThe transitions \u0027wontfix\u0027 and \u0027falsepositive\u0027 require the permission \u0027Administer Issues\u0027.\u003cbr/\u003eThe transitions involving security hotspots require the permission \u0027Administer Security Hotspot\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "transition",
+                            "description": "Transition",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "confirm",
+                                "unconfirm",
+                                "reopen",
+                                "resolve",
+                                "falsepositive",
+                                "wontfix",
+                                "close",
+                                "setinreview",
+                                "resolveasreviewed",
+                                "resetastoreview"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "edit_comment",
+                    "description": "Edit a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response returns the issue with all its details",
+                            "version": "6.3"
+                        },
+                        {
+                            "description": "the \u0027key\u0027 parameter has been renamed comment",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "comment",
+                            "description": "Comment key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedKey": "key",
+                            "deprecatedKeySince": "6.3"
+                        },
+                        {
+                            "key": "text",
+                            "description": "Comment text",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Won\u0027t fix because it doesn\u0027t apply to the context"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for issues.\u003cbr\u003eRequires the \u0027Browse\u0027 permission on the specified project(s).",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "additionalFields",
+                            "description": "Comma-separated list of the optional fields to be returned in response. Action plans are dropped in 5.5, it is not returned in the response.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "_all",
+                                "comments",
+                                "languages",
+                                "actionPlans",
+                                "rules",
+                                "transitions",
+                                "actions",
+                                "users"
+                            ]
+                        },
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "assigned",
+                            "description": "To retrieve assigned or unassigned issues",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "assignees",
+                            "description": "Comma-separated list of assignee logins. The value \u0027__me__\u0027 can be used as a placeholder for user who performs the request",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "admin,usera,__me__"
+                        },
+                        {
+                            "key": "author",
+                            "description": "SCM accounts. To set several values, the parameter must be called once for each value.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "author\u003dtorvalds@linux-foundation.org\u0026author\u003dlinux@fondation.org"
+                        },
+                        {
+                            "key": "authors",
+                            "description": "This parameter is deprecated, please use \u0027author\u0027 instead",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "torvalds@linux-foundation.org",
+                            "deprecatedSince": "7.7"
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "componentKeys",
+                            "description": "Comma-separated list of component keys. Retrieve issues associated to a specific list of components (and all its descendants). A component can be a project, directory or file.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "createdAfter",
+                            "description": "To retrieve issues created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided. \u003cbr\u003eIf this parameter is set, createdSince must not be set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "createdAt",
+                            "description": "Datetime to retrieve issues created during a specific analysis",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "createdBefore",
+                            "description": "To retrieve issues created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "createdInLast",
+                            "description": "To retrieve issues created during a time span before the current time (exclusive). Accepted units are \u0027y\u0027 for year, \u0027m\u0027 for month, \u0027w\u0027 for week and \u0027d\u0027 for day. If this parameter is set, createdAfter must not be set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "1m2w (1 month 2 weeks)"
+                        },
+                        {
+                            "key": "cwe",
+                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select issues not associated to any CWE.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "12,125,unknown"
+                        },
+                        {
+                            "key": "facetMode",
+                            "description": "Choose the returned value for facet items, either count of issues or sum of remediation effort.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "count",
+                            "deprecatedSince": "7.9",
+                            "possibleValues": [
+                                "count",
+                                "effort"
+                            ]
+                        },
+                        {
+                            "key": "facets",
+                            "description": "Comma-separated list of the facets to be computed. No facet is computed by default.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "projects",
+                                "moduleUuids",
+                                "fileUuids",
+                                "assigned_to_me",
+                                "severities",
+                                "statuses",
+                                "resolutions",
+                                "rules",
+                                "assignees",
+                                "authors",
+                                "author",
+                                "directories",
+                                "languages",
+                                "tags",
+                                "types",
+                                "owaspTop10",
+                                "sansTop25",
+                                "cwe",
+                                "createdAt",
+                                "sonarsourceSecurity"
+                            ]
+                        },
+                        {
+                            "key": "issues",
+                            "description": "Comma-separated list of issue keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5bccd6e8-f525-43a2-8d76-fcb13dde79ef"
+                        },
+                        {
+                            "key": "languages",
+                            "description": "Comma-separated list of languages. Available since 4.4",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java,js"
+                        },
+                        {
+                            "key": "onComponentOnly",
+                            "description": "Return only issues at a component\u0027s level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "owaspTop10",
+                            "description": "Comma-separated list of OWASP Top 10 lowercase categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "a1",
+                                "a2",
+                                "a3",
+                                "a4",
+                                "a5",
+                                "a6",
+                                "a7",
+                                "a8",
+                                "a9",
+                                "a10"
+                            ]
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        },
+                        {
+                            "key": "resolutions",
+                            "description": "Comma-separated list of resolutions",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "FIXED,REMOVED",
+                            "possibleValues": [
+                                "FALSE-POSITIVE",
+                                "WONTFIX",
+                                "FIXED",
+                                "REMOVED"
+                            ]
+                        },
+                        {
+                            "key": "resolved",
+                            "description": "To match resolved or unresolved issues",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "rules",
+                            "description": "Comma-separated list of coding rule keys. Format is \u0026lt;repository\u0026gt;:\u0026lt;rule\u0026gt;",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid:AvoidCycles"
+                        },
+                        {
+                            "key": "s",
+                            "description": "Sort field",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "CREATION_DATE",
+                                "UPDATE_DATE",
+                                "CLOSE_DATE",
+                                "ASSIGNEE",
+                                "SEVERITY",
+                                "STATUS",
+                                "FILE_LINE",
+                                "HOTSPOTS"
+                            ]
+                        },
+                        {
+                            "key": "sansTop25",
+                            "description": "Comma-separated list of SANS Top 25 categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "insecure-interaction",
+                                "risky-resource",
+                                "porous-defenses"
+                            ]
+                        },
+                        {
+                            "key": "severities",
+                            "description": "Comma-separated list of severities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BLOCKER,CRITICAL",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "sinceLeakPeriod",
+                            "description": "To retrieve issues created since the leak period.\u003cbr\u003eIf this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "sonarsourceSecurity",
+                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select issues not associated with any category",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "sql-injection",
+                                "command-injection",
+                                "path-traversal-injection",
+                                "ldap-injection",
+                                "xpath-injection",
+                                "rce",
+                                "dos",
+                                "ssrf",
+                                "csrf",
+                                "xss",
+                                "log-injection",
+                                "http-response-splitting",
+                                "open-redirect",
+                                "xxe",
+                                "object-injection",
+                                "weak-cryptography",
+                                "auth",
+                                "insecure-conf",
+                                "encrypt-data",
+                                "traceability",
+                                "file-manipulation",
+                                "others"
+                            ]
+                        },
+                        {
+                            "key": "statuses",
+                            "description": "Comma-separated list of statuses",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "OPEN,REOPENED",
+                            "possibleValues": [
+                                "OPEN",
+                                "CONFIRMED",
+                                "REOPENED",
+                                "RESOLVED",
+                                "CLOSED"
+                            ]
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,convention"
+                        },
+                        {
+                            "key": "types",
+                            "description": "Comma-separated list of types.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CODE_SMELL,BUG",
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "set_severity",
+                    "description": "Change severity.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "severity",
+                            "description": "New severity",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "set_tags",
+                    "description": "Set tags on an issue. \u003cbr/\u003eRequires authentication and Browse permission on project",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "response contains issue information instead of list of tags",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedKey": "key",
+                            "deprecatedKeySince": "6.3"
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags. All tags are removed if parameter is empty or not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,cwe,misra-c"
+                        }
+                    ]
+                },
+                {
+                    "key": "set_type",
+                    "description": "Change type of issue, for instance from \u0027code smell\u0027 to \u0027bug\u0027.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "the database ids of the components are removed from the response",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
+                            "version": "6.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "issue",
+                            "description": "Issue key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "type",
+                            "description": "New type",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "tags",
+                    "description": "List tags matching a given query",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Result doesn\u0027t include rules tags anymore",
+                            "version": "7.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 100",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "10",
+                            "exampleValue": "20",
+                            "maximumValue": 100
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to tags that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "misra"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/languages",
+            "description": "Get the list of programming languages supported in this instance.",
+            "actions": [
+                {
+                    "key": "list",
+                    "description": "List supported programming languages",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "ps",
+                            "description": "The size of the list to return, 0 for all languages",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "0",
+                            "exampleValue": "25"
+                        },
+                        {
+                            "key": "q",
+                            "description": "A pattern to match language keys/names against",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/measures",
+            "description": "Get components or children with specified measures.",
+            "actions": [
+                {
+                    "key": "component",
+                    "description": "Return component with specified measures. The componentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the project of specified component.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "the response field id is deprecated. Use key instead.",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "the response field refId is deprecated. Use refKey instead.",
+                            "version": "6.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "additionalFields",
+                            "description": "Comma-separated list of additional fields that can be returned in the response.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "periods,metrics",
+                            "possibleValues": [
+                                "metrics",
+                                "periods"
+                            ]
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "componentKey",
+                            "deprecatedKeySince": "6.6"
+                        },
+                        {
+                            "key": "componentId",
+                            "description": "Component id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6"
+                        },
+                        {
+                            "key": "developerId",
+                            "description": "Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "6.4"
+                        },
+                        {
+                            "key": "developerKey",
+                            "description": "Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "6.4"
+                        },
+                        {
+                            "key": "metricKeys",
+                            "description": "Comma-separated list of metric keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "ncloc,complexity,violations"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        }
+                    ]
+                },
+                {
+                    "key": "component_tree",
+                    "description": "Navigate through components based on the chosen strategy with specified measures. The baseComponentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "field \u0027bestValue\u0027 is added to the response",
+                            "version": "7.2"
+                        },
+                        {
+                            "description": "the response field id is deprecated. Use key instead.",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "the response field refId is deprecated. Use refKey instead.",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "Number of metric keys is limited to 15",
+                            "version": "6.3"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "additionalFields",
+                            "description": "Comma-separated list of additional fields that can be returned in the response.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "periods,metrics",
+                            "possibleValues": [
+                                "metrics",
+                                "periods"
+                            ]
+                        },
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "baseComponentId",
+                            "description": "Base component id. The search is based on this component.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FLz",
+                            "deprecatedSince": "6.6"
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Component key. The search is based on this component.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "baseComponentKey",
+                            "deprecatedKeySince": "6.6"
+                        },
+                        {
+                            "key": "developerId",
+                            "description": "Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "6.4"
+                        },
+                        {
+                            "key": "developerKey",
+                            "description": "Deprecated parameter, used previously with the Developer Cockpit plugin. No measures are returned if parameter is set.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "6.4"
+                        },
+                        {
+                            "key": "metricKeys",
+                            "description": "Comma-separated list of metric keys. Types DISTRIB, DATA are not allowed.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "ncloc,complexity,violations",
+                            "maxValuesAllowed": 15
+                        },
+                        {
+                            "key": "metricPeriodSort",
+                            "description": "Sort measures by leak period or not ?. The \u0027s\u0027 parameter must contain the \u0027metricPeriod\u0027 value.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "1"
+                            ]
+                        },
+                        {
+                            "key": "metricSort",
+                            "description": "Metric key to sort by. The \u0027s\u0027 parameter must contain the \u0027metric\u0027 or \u0027metricPeriod\u0027 value. It must be part of the \u0027metricKeys\u0027 parameter",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ncloc"
+                        },
+                        {
+                            "key": "metricSortFilter",
+                            "description": "Filter components. Sort must be on a metric. Possible values are: \u003cul\u003e\u003cli\u003eall: return all components\u003c/li\u003e\u003cli\u003ewithMeasuresOnly: filter out components that do not have a measure on the sorted metric\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "all",
+                            "possibleValues": [
+                                "all",
+                                "withMeasuresOnly"
+                            ]
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "FILE_NAM",
+                            "minimumLength": 3
+                        },
+                        {
+                            "key": "qualifiers",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "BRC",
+                                "DIR",
+                                "FIL",
+                                "TRK",
+                                "UTS"
+                            ]
+                        },
+                        {
+                            "key": "s",
+                            "description": "Comma-separated list of sort fields",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "name",
+                            "exampleValue": "name,path",
+                            "possibleValues": [
+                                "metric",
+                                "metricPeriod",
+                                "name",
+                                "path",
+                                "qualifier"
+                            ]
+                        },
+                        {
+                            "key": "strategy",
+                            "description": "Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "all",
+                            "possibleValues": [
+                                "all",
+                                "children",
+                                "leaves"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "search_history",
+                    "description": "Search measures history of a component.\u003cbr\u003eMeasures are ordered chronologically.\u003cbr\u003ePagination applies to the number of measures for each metric.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "from",
+                            "description": "Filter measures created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "metrics",
+                            "description": "Comma-separated list of metric keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "ncloc,coverage,new_violations"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 1000",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 1000
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        },
+                        {
+                            "key": "to",
+                            "description": "Filter measures created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/metrics",
+            "description": "Get information on automatic metrics, and manage custom metrics. See also api/custom_measures.",
+            "actions": [
+                {
+                    "key": "domains",
+                    "description": "List all custom metric domains.",
+                    "deprecatedSince": "7.7",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                },
+                {
+                    "key": "search",
+                    "description": "Search for metrics",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "f",
+                            "description": "Comma-separated list of the fields to be returned in response. All the fields are returned by default.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "7.7",
+                            "possibleValues": [
+                                "name",
+                                "description",
+                                "domain",
+                                "direction",
+                                "qualitative",
+                                "hidden",
+                                "decimalScale"
+                            ]
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        }
+                    ]
+                },
+                {
+                    "key": "types",
+                    "description": "List all available metric types.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                }
+            ]
+        },
+        {
+            "path": "api/notifications",
+            "description": "Manage notifications of the authenticated user",
+            "actions": [
+                {
+                    "key": "add",
+                    "description": "Add a notification for the authenticated user.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e \u003cli\u003eAuthentication if no login is provided. If a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e \u003cli\u003eIf a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "channel",
+                            "description": "Channel through which the notification is sent. For example, notifications can be sent by email.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "EmailNotificationChannel",
+                            "possibleValues": [
+                                "EmailNotificationChannel"
+                            ]
+                        },
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "type",
+                            "description": "Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "SQ-MyNewIssues"
+                        }
+                    ]
+                },
+                {
+                    "key": "list",
+                    "description": "List notifications of the authenticated user",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false
+                        }
+                    ]
+                },
+                {
+                    "key": "remove",
+                    "description": "Remove a notification for the authenticated user",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "channel",
+                            "description": "Channel through which the notification is sent. For example, notifications can be sent by email.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "EmailNotificationChannel",
+                            "possibleValues": [
+                                "EmailNotificationChannel"
+                            ]
+                        },
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "type",
+                            "description": "Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "SQ-MyNewIssues"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/permissions",
+            "description": "Manage permission templates, and the granting and revoking of permissions at the global and project levels.",
+            "actions": [
+                {
+                    "key": "add_group",
+                    "description": "Add permission to a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group name or group id must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "groupId",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "groupName",
+                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "add_group_to_template",
+                    "description": "Add a group to a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "groupId",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "groupName",
+                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "add_project_creator_to_template",
+                    "description": "Add a project creator to a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "add_user",
+                    "description": "Add permission to a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "If organizationKey and projectId are both set, the organizationKey must be the key of the organization of the project",
+                            "version": "7.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "add_user_to_template",
+                    "description": "Add a user to a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "apply_template",
+                    "description": "Apply a permission template to one project.\u003cbr\u003eThe project id or project key must be provided.\u003cbr\u003eThe template id or name must be provided.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "bulk_apply_template",
+                    "description": "Apply a permission template to several projects.\u003cbr /\u003eThe template id or name must be provided.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "Parameter projects accepts maximum 1000 values",
+                            "version": "6.7.2"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "analyzedBefore",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "onProvisionedOnly",
+                            "description": "Filter the projects that are provisioned",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "projects",
+                            "description": "Comma-separated list of project keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project,another_project",
+                            "maxValuesAllowed": 1000
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "apac"
+                        },
+                        {
+                            "key": "qualifiers",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "TRK",
+                            "deprecatedKey": "qualifier",
+                            "deprecatedKeySince": "6.6",
+                            "possibleValues": [
+                                "TRK"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "create_template",
+                    "description": "Create a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "description",
+                            "description": "Description",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Permissions for all projects related to the financial service"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Financial Service Permissions"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "projectKeyPattern",
+                            "description": "Project key pattern. Must be a valid Java regular expression",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": ".*\\.finance\\..*"
+                        }
+                    ]
+                },
+                {
+                    "key": "delete_template",
+                    "description": "Delete a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_group",
+                    "description": "Remove a permission from a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group id or group name must be provided, not both.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "groupId",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "groupName",
+                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_group_from_template",
+                    "description": "Remove a group from a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "groupId",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "groupName",
+                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_project_creator_from_template",
+                    "description": "Remove a project creator from a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_user",
+                    "description": "Remove permission from a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_user_from_template",
+                    "description": "Remove a user from a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "permission",
+                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "admin",
+                                "codeviewer",
+                                "issueadmin",
+                                "securityhotspotadmin",
+                                "scan",
+                                "user"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "search_global_permissions",
+                    "description": "List global permissions. \u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027",
+                    "deprecatedSince": "6.5",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "search_project_permissions",
+                    "description": "List project permissions. A project can be a technical project, a view or a developer.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "deprecatedSince": "6.5",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ce4c03d6-430f-40a9-b777-ad877c00aa4d"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "25",
+                            "exampleValue": "20"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "apac"
+                        },
+                        {
+                            "key": "qualifier",
+                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "TRK"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "search_templates",
+                    "description": "List permission templates.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to permission template names that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "defau"
+                        }
+                    ]
+                },
+                {
+                    "key": "set_default_template",
+                    "description": "Set a permission template as default.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Key of organization, used when group name is set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualifier",
+                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "TRK",
+                            "possibleValues": [
+                                "TRK"
+                            ]
+                        },
+                        {
+                            "key": "templateId",
+                            "description": "Template id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "templateName",
+                            "description": "Template name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default Permission Template for Projects"
+                        }
+                    ]
+                },
+                {
+                    "key": "update_template",
+                    "description": "Update a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "description",
+                            "description": "Description",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Permissions for all projects related to the financial service"
+                        },
+                        {
+                            "key": "id",
+                            "description": "Id",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "af8cb8cc-1e78-4c4e-8c00-ee8e814009a5"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Financial Service Permissions"
+                        },
+                        {
+                            "key": "projectKeyPattern",
+                            "description": "Project key pattern. Must be a valid Java regular expression",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": ".*\\.finance\\..*"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_analyses",
+            "description": "Manage project analyses.",
+            "actions": [
+                {
+                    "key": "create_event",
+                    "description": "Create a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be created.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "analysis",
+                            "description": "Analysis key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "category",
+                            "description": "Category",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "OTHER",
+                            "possibleValues": [
+                                "VERSION",
+                                "OTHER"
+                            ]
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "5.6",
+                            "maximumLength": 400
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete a project analysis.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the project of the specified analysis.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "analysis",
+                            "description": "Analysis key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL1"
+                        }
+                    ]
+                },
+                {
+                    "key": "delete_event",
+                    "description": "Delete a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be deleted.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "event",
+                            "description": "Event key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FLz"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search a project analyses and attached events.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Add QualityGate information on Applications",
+                            "version": "7.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Key of a long lived branch",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "category",
+                            "description": "Event category. Filter analyses that have at least one event of the category specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "OTHER",
+                            "possibleValues": [
+                                "VERSION",
+                                "OTHER",
+                                "QUALITY_PROFILE",
+                                "QUALITY_GATE",
+                                "DEFINITION_CHANGE"
+                            ]
+                        },
+                        {
+                            "key": "from",
+                            "description": "Filter analyses created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2013-05-01"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "to",
+                            "description": "Filter analyses created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        }
+                    ]
+                },
+                {
+                    "key": "set_baseline",
+                    "description": "Set an analysis as the baseline of the New Code Period on a project or a long-lived branch.\u003cbr/\u003eThis manually set baseline overrides the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "analysis",
+                            "description": "Analysis key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false
+                        }
+                    ]
+                },
+                {
+                    "key": "unset_baseline",
+                    "description": "Unset any manually-set New Code Period baseline on a project or a long-lived branch.\u003cbr/\u003eUnsetting a manual baseline restores the use of the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false
+                        }
+                    ]
+                },
+                {
+                    "key": "update_event",
+                    "description": "Update a project analysis event.\u003cbr\u003eOnly events of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be updated.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "event",
+                            "description": "Event key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL5"
+                        },
+                        {
+                            "key": "name",
+                            "description": "New name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "5.6",
+                            "maximumLength": 400
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_badges",
+            "description": "Generate badges based on quality gates or measures",
+            "actions": [
+                {
+                    "key": "measure",
+                    "description": "Generate badge for project\u0027s measure as an SVG.\u003cbr/\u003eRequires a security token for private projects.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Long-lived branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "metric",
+                            "description": "Metric key",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "bugs",
+                                "code_smells",
+                                "coverage",
+                                "duplicated_lines_density",
+                                "ncloc",
+                                "sqale_rating",
+                                "alert_status",
+                                "reliability_rating",
+                                "security_rating",
+                                "sqale_index",
+                                "vulnerabilities"
+                            ]
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project or application key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "token",
+                            "description": "Security token",
+                            "required": false,
+                            "internal": false
+                        }
+                    ]
+                },
+                {
+                    "key": "quality_gate",
+                    "description": "Generate badge for project\u0027s quality gate as an SVG.\u003cbr/\u003eRequires a security token for private projects.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Long-lived branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project or application key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "token",
+                            "description": "Security token",
+                            "required": false,
+                            "internal": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_branches",
+            "description": "Manage branch (only available when the Branch plugin is installed)",
+            "actions": [
+                {
+                    "key": "delete",
+                    "description": "Delete a non-main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Name of the branch",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "branch1"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "list",
+                    "description": "List the branches of a project.\u003cbr/\u003eRequires \u0027Browse\u0027 or \u0027Execute analysis\u0027 rights on the specified project.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Application can be used on this web service",
+                            "version": "7.2"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "rename",
+                    "description": "Rename the main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "name",
+                            "description": "New name of the main branch",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "branch1",
+                            "maximumLength": 255
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_links",
+            "description": "Manage projects links.",
+            "actions": [
+                {
+                    "key": "create",
+                    "description": "Create a new project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "name",
+                            "description": "Link name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Custom",
+                            "maximumLength": 128
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "url",
+                            "description": "Link url",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "http://example.com",
+                            "maximumLength": 2048
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete existing project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Link id",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "17"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "List links of a project.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "projectId",
+                            "description": "Project Id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project Key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_pull_requests",
+            "description": "Manage pull request (only available when the Branch plugin is installed)",
+            "actions": [
+                {
+                    "key": "delete",
+                    "description": "Delete a pull request.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1543"
+                        }
+                    ]
+                },
+                {
+                    "key": "list",
+                    "description": "List the pull requests of a project.\u003cbr/\u003eOne of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Browse\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Execute Analysis\u0027 rights on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/project_tags",
+            "description": "Manage project tags",
+            "actions": [
+                {
+                    "key": "search",
+                    "description": "Search tags",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 100",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "10",
+                            "exampleValue": "20",
+                            "maximumValue": 100
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to tags that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "off"
+                        }
+                    ]
+                },
+                {
+                    "key": "set",
+                    "description": "Set tags on a project.\u003cbr\u003eRequires the following permission: \u0027Administer\u0027 rights on the specified project",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "finance, offshore"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/projects",
+            "description": "Manage project existence.",
+            "actions": [
+                {
+                    "key": "bulk_delete",
+                    "description": "Delete one or several projects.\u003cbr /\u003eOnly the 1\u0027000 first items in project filters are taken into account.\u003cbr /\u003eRequires \u0027Administer System\u0027 permission.\u003cbr /\u003eAt least one parameter is required among analyzedBefore, projects and q",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "At least one parameter is required among analyzedBefore, projects and q",
+                            "version": "7.8"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "analyzedBefore",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "onProvisionedOnly",
+                            "description": "Filter the projects that are provisioned",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "The key of the organization",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "projects",
+                            "description": "Comma-separated list of project keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project,another_project"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar"
+                        },
+                        {
+                            "key": "qualifiers",
+                            "description": "No longer used",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "TRK",
+                            "deprecatedSince": "8.0",
+                            "possibleValues": [
+                                "TRK"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "bulk_update_key",
+                    "description": "Bulk update a project or module key and all its sub-components keys. The bulk update allows to replace a part of the current key by another string on the current project and all its sub-modules.\u003cbr\u003eIt\u0027s possible to simulate the bulk update by setting the parameter \u0027dryRun\u0027 at true. No key is updated with a dry run.\u003cbr\u003eEx: to rename a project with key \u0027my_project\u0027 to \u0027my_new_project\u0027 and all its sub-components keys, call the WS with parameters:\u003cul\u003e  \u003cli\u003eproject: my_project\u003c/li\u003e  \u003cli\u003efrom: my_\u003c/li\u003e  \u003cli\u003eto: my_new_\u003c/li\u003e\u003c/ul\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "deprecatedSince": "7.6",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "dryRun",
+                            "description": "Simulate bulk update. No component key is updated.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "from",
+                            "description": "String to match in components keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "_old"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project or module key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_old_project"
+                        },
+                        {
+                            "key": "to",
+                            "description": "String replacement in components keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "_new"
+                        }
+                    ]
+                },
+                {
+                    "key": "create",
+                    "description": "Create a project.\u003cbr/\u003eRequires \u0027Create Projects\u0027 permission",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The \u0027visibility\u0027 parameter is public",
+                            "version": "7.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "SCM Branch of the project. The key of the project will become key:branch, for instance \u0027SonarQube:branch-5.0\u0027",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "branch-5.0",
+                            "deprecatedSince": "7.8"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name of the project. If name is longer than 500, it is abbreviated.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "SonarQube"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "The key of the organization",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "project",
+                            "description": "Key of the project",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "maximumLength": 400
+                        },
+                        {
+                            "key": "visibility",
+                            "description": "Whether the created project should be visible to everyone, or only specific user/groups.\u003cbr/\u003eIf no visibility is specified, the default project visibility of the organization will be used.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "private",
+                                "public"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete a project.\u003cbr\u003e Requires \u0027Administer System\u0027 permission or \u0027Administer\u0027 permission on the project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for projects to administrate them.\u003cbr\u003eRequires \u0027System Administrator\u0027 permission",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "analyzedBefore",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "onProvisionedOnly",
+                            "description": "Filter the projects that are provisioned",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "The key of the organization",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "projects",
+                            "description": "Comma-separated list of project keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project,another_project",
+                            "maxValuesAllowed": 1000
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar"
+                        },
+                        {
+                            "key": "qualifiers",
+                            "description": "No longer used",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "TRK",
+                            "deprecatedSince": "8.0",
+                            "possibleValues": [
+                                "TRK"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "update_key",
+                    "description": "Update a project or module key and all its sub-components keys.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "Ability to update key of a disabled module",
+                            "version": "7.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "from",
+                            "description": "Project or module key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_old_project"
+                        },
+                        {
+                            "key": "to",
+                            "description": "New component key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_new_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "update_visibility",
+                    "description": "Updates visibility of a project.\u003cbr\u003eRequires \u0027Project administer\u0027 permission on the specified project",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "visibility",
+                            "description": "New visibility",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "private",
+                                "public"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/properties",
+            "description": "This web service is deprecated, please use api/settings instead.",
+            "actions": [
+                {
+                    "key": "index",
+                    "description": "This web service is deprecated, please use api/settings/values instead.",
+                    "deprecatedSince": "6.3",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "format",
+                            "description": "Only json response format is available",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "json"
+                            ]
+                        },
+                        {
+                            "key": "id",
+                            "description": "Setting key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar.test.inclusions"
+                        },
+                        {
+                            "key": "resource",
+                            "description": "Component key or database id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/qualitygates",
+            "description": "Manage quality gates, including conditions and project association.",
+            "actions": [
+                {
+                    "key": "copy",
+                    "description": "Copy a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "The ID of the source quality gate",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "name",
+                            "description": "The name of the quality gate to create",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Quality Gate"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "create",
+                    "description": "Create a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "name",
+                            "description": "The name of the quality gate to create",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Quality Gate",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "create_condition",
+                    "description": "Add a new condition to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "Made \u0027error\u0027 parameter mandatory",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "Reduced the possible values of \u0027op\u0027 parameter to LT and GT",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "error",
+                            "description": "Condition error threshold",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "10",
+                            "maximumLength": 64
+                        },
+                        {
+                            "key": "gateId",
+                            "description": "ID of the quality gate",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "metric",
+                            "description": "Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "blocker_violations, vulnerabilities, new_code_smells"
+                        },
+                        {
+                            "key": "op",
+                            "description": "Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "GT",
+                            "possibleValues": [
+                                "LT",
+                                "GT"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "delete_condition",
+                    "description": "Delete a condition from a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Condition ID",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "2"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "deselect",
+                    "description": "Remove the association of a project from a quality gate.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer Quality Gates\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "The parameter \u0027gateId\u0027 was removed",
+                            "version": "6.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.1"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "destroy",
+                    "description": "Delete a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "ID of the quality gate to delete",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "get_by_project",
+                    "description": "Get the quality gate of a project.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The parameter \u0027projectId\u0027 has been removed",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "The parameter \u0027projectKey\u0027 has been renamed to \u0027project\u0027",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "This webservice is now part of the public API",
+                            "version": "6.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "list",
+                    "description": "Get a list of quality gates",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "\u0027isDefault\u0027 field is added on quality gate",
+                            "version": "7.0"
+                        },
+                        {
+                            "description": "\u0027default\u0027 field on root level is deprecated",
+                            "version": "7.0"
+                        },
+                        {
+                            "description": "\u0027isBuiltIn\u0027 field is added in the response",
+                            "version": "7.0"
+                        },
+                        {
+                            "description": "\u0027actions\u0027 fields are added in the response",
+                            "version": "7.0"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "project_status",
+                    "description": "Get the quality gate status of a project or a Compute Engine task.\u003cbr /\u003eEither \u0027analysisId\u0027, \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided\u003cbr /\u003eThe different statuses returned are: OK, WARN, ERROR, NONE. The NONE status is returned when there is no quality gate associated with the analysis.\u003cbr /\u003eReturns an HTTP code 404 if the analysis associated with the task is not found or does not exist.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The parameters \u0027branch\u0027 and \u0027pullRequest\u0027 were added",
+                            "version": "7.7"
+                        },
+                        {
+                            "description": "The field \u0027warning\u0027 is deprecated from the response",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "The field \u0027ignoredConditions\u0027 is added to the response",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "analysisId",
+                            "description": "Analysis id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL1"
+                        },
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id. Doesn\u0027t work with branches or pull requests",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        }
+                    ]
+                },
+                {
+                    "key": "rename",
+                    "description": "Rename a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "ID of the quality gate to rename",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "name",
+                            "description": "New name of the quality gate",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Quality Gate",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for projects associated (or not) to a quality gate.\u003cbr/\u003eOnly authorized projects for current user will be returned.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "New field \u0027paging\u0027 in response",
+                            "version": "7.9"
+                        },
+                        {
+                            "description": "New field \u0027key\u0027 returning the project key in \u0027results\u0027 response",
+                            "version": "7.9"
+                        },
+                        {
+                            "description": "Field \u0027more\u0027 is deprecated in the response",
+                            "version": "7.9"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "gateId",
+                            "description": "Quality Gate ID",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "page",
+                            "description": "Page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "2"
+                        },
+                        {
+                            "key": "pageSize",
+                            "description": "Page size",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "10"
+                        },
+                        {
+                            "key": "query",
+                            "description": "To search for projects containing this string. If this parameter is set, \"selected\" is set to \"all\".",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "abc"
+                        },
+                        {
+                            "key": "selected",
+                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "selected",
+                            "possibleValues": [
+                                "all",
+                                "deselected",
+                                "selected"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "select",
+                    "description": "Associate a project to a quality gate.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eProject id as a numeric value is deprecated since 6.1. Please use the id similar to \u0027AU-TpxcA-iU5OvuD2FLz\u0027.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "gateId",
+                            "description": "Quality gate id",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "projectId",
+                            "description": "Project id. Project id as an numeric value is deprecated since 6.1",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "set_as_default",
+                    "description": "Set a quality gate as the default quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "ID of the quality gate to set as default",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "show",
+                    "description": "Display the details of a quality gate",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "\u0027period\u0027 and \u0027warning\u0027 fields of conditions are removed from the response",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "\u0027isBuiltIn\u0027 field is added to the response",
+                            "version": "7.0"
+                        },
+                        {
+                            "description": "\u0027actions\u0027 field is added in the response",
+                            "version": "7.0"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "ID of the quality gate. Either id or name must be set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "1"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name of the quality gate. Either id or name must be set",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "My Quality Gate"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "unset_default",
+                    "description": "This webservice is no more available : a default quality gate is mandatory.",
+                    "deprecatedSince": "7.0",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Unset a quality gate is no more authorized",
+                            "version": "7.0"
+                        }
+                    ]
+                },
+                {
+                    "key": "update_condition",
+                    "description": "Update a condition attached to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "Made \u0027error\u0027 parameter mandatory",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "Reduced the possible values of \u0027op\u0027 parameter to LT and GT",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "error",
+                            "description": "Condition error threshold",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "10",
+                            "maximumLength": 64
+                        },
+                        {
+                            "key": "id",
+                            "description": "Condition ID",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "10"
+                        },
+                        {
+                            "key": "metric",
+                            "description": "Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "blocker_violations, vulnerabilities, new_code_smells"
+                        },
+                        {
+                            "key": "op",
+                            "description": "Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "GT",
+                            "possibleValues": [
+                                "LT",
+                                "GT"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/qualityprofiles",
+            "description": "Manage quality profiles.",
+            "actions": [
+                {
+                    "key": "activate_rule",
+                    "description": "Activate a rule on a Quality Profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedKey": "profile_key",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "params",
+                            "description": "Parameters as semi-colon list of \u003ccode\u003ekey\u003dvalue\u003c/code\u003e. Ignored if parameter reset is true.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "params\u003dkey1\u003dv1;key2\u003dv2"
+                        },
+                        {
+                            "key": "reset",
+                            "description": "Reset severity and parameters of activated rule. Set the values defined on parent profile or from rule default values.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "rule",
+                            "description": "Rule key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "squid:AvoidCycles",
+                            "deprecatedKey": "rule_key",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "severity",
+                            "description": "Severity. Ignored if parameter reset is true.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "activate_rules",
+                    "description": "Bulk-activate rules on one quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "activation",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "active_severities",
+                            "description": "Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "available_since",
+                            "description": "Filters rules added since date. Format is yyyy-MM-dd",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2014-06-22"
+                        },
+                        {
+                            "key": "cwe",
+                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "12,125,unknown"
+                        },
+                        {
+                            "key": "inheritance",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "INHERITED,OVERRIDES",
+                            "possibleValues": [
+                                "NONE",
+                                "INHERITED",
+                                "OVERRIDES"
+                            ]
+                        },
+                        {
+                            "key": "is_template",
+                            "description": "Filter template rules",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "languages",
+                            "description": "Comma-separated list of languages",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java,js"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "owaspTop10",
+                            "description": "Comma-separated list of OWASP Top 10 lowercase categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "a1",
+                                "a2",
+                                "a3",
+                                "a4",
+                                "a5",
+                                "a6",
+                                "a7",
+                                "a8",
+                                "a9",
+                                "a10"
+                            ]
+                        },
+                        {
+                            "key": "q",
+                            "description": "UTF-8 search query",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "xpath",
+                            "minimumLength": 2
+                        },
+                        {
+                            "key": "qprofile",
+                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "repositories",
+                            "description": "Comma-separated list of repositories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "checkstyle,findbugs"
+                        },
+                        {
+                            "key": "rule_key",
+                            "description": "Key of rule to search for",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid:S001"
+                        },
+                        {
+                            "key": "s",
+                            "description": "Sort field",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "name",
+                            "possibleValues": [
+                                "name",
+                                "updatedAt",
+                                "createdAt",
+                                "key"
+                            ]
+                        },
+                        {
+                            "key": "sansTop25",
+                            "description": "Comma-separated list of SANS Top 25 categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "insecure-interaction",
+                                "risky-resource",
+                                "porous-defenses"
+                            ]
+                        },
+                        {
+                            "key": "severities",
+                            "description": "Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "sonarsourceSecurity",
+                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sql-injection,command-injection,others",
+                            "possibleValues": [
+                                "sql-injection",
+                                "command-injection",
+                                "path-traversal-injection",
+                                "ldap-injection",
+                                "xpath-injection",
+                                "rce",
+                                "dos",
+                                "ssrf",
+                                "csrf",
+                                "xss",
+                                "log-injection",
+                                "http-response-splitting",
+                                "open-redirect",
+                                "xxe",
+                                "object-injection",
+                                "weak-cryptography",
+                                "auth",
+                                "insecure-conf",
+                                "encrypt-data",
+                                "traceability",
+                                "file-manipulation",
+                                "others"
+                            ]
+                        },
+                        {
+                            "key": "statuses",
+                            "description": "Comma-separated list of status codes",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "READY",
+                            "possibleValues": [
+                                "BETA",
+                                "DEPRECATED",
+                                "READY",
+                                "REMOVED"
+                            ]
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,java8"
+                        },
+                        {
+                            "key": "targetKey",
+                            "description": "Quality Profile key on which the rule activation is done. To retrieve a quality profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL0",
+                            "deprecatedKey": "profile_key",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "targetSeverity",
+                            "description": "Severity to set on the activated rules",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedKey": "activation_severity",
+                            "deprecatedKeySince": "6.5",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "template_key",
+                            "description": "Key of the template rule to filter on. Used to search for the custom rules based on this template.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java:S001"
+                        },
+                        {
+                            "key": "types",
+                            "description": "Comma-separated list of types. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BUG",
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY",
+                                "SECURITY_HOTSPOT"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "add_project",
+                    "description": "Associate a project with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "projectKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "projectUuid",
+                            "description": "Project ID. Either this parameter or \u0027project\u0027 must be set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL5",
+                            "deprecatedSince": "6.5"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "backup",
+                    "description": "Backup a quality profile in XML form. The exported profile can be restored through api/qualityprofiles/restore.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "change_parent",
+                    "description": "Change a quality profile\u0027s parent.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "parentKey",
+                            "description": "New parent profile key.\u003cbr\u003e If no profile is provided, the inheritance link with current parent profile (if any) is broken, which deactivates all rules which come from the parent and are not overridden.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FLz",
+                            "deprecatedSince": "6.6"
+                        },
+                        {
+                            "key": "parentQualityProfile",
+                            "description": "Quality profile name. If this parameter is set, \u0027parentKey\u0027 must not be set and \u0027language\u0027 must be set to disambiguate.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "changelog",
+                    "description": "Get the history of changes on a quality profile: rule activation/deactivation, change in parameters/severity. Events are ordered by date in descending order (most recent first).",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "50",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        },
+                        {
+                            "key": "since",
+                            "description": "Start date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        },
+                        {
+                            "key": "to",
+                            "description": "End date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
+                        }
+                    ]
+                },
+                {
+                    "key": "copy",
+                    "description": "Copy a quality profile.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "fromKey",
+                            "description": "Quality profile key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "toName",
+                            "description": "Name for the new quality profile.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Sonar way"
+                        }
+                    ]
+                },
+                {
+                    "key": "create",
+                    "description": "Create a quality profile.\u003cbr\u003eRequires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "language",
+                            "description": "Quality profile language",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "js",
+                            "possibleValues": [
+                                "abap",
+                                "apex",
+                                "c",
+                                "cloudformation",
+                                "cobol",
+                                "cpp",
+                                "cs",
+                                "css",
+                                "flex",
+                                "go",
+                                "java",
+                                "js",
+                                "json",
+                                "jsp",
+                                "kotlin",
+                                "objc",
+                                "php",
+                                "plsql",
+                                "py",
+                                "ruby",
+                                "scala",
+                                "swift",
+                                "terraform",
+                                "ts",
+                                "tsql",
+                                "vbnet",
+                                "web",
+                                "xml",
+                                "yaml"
+                            ]
+                        },
+                        {
+                            "key": "name",
+                            "description": "Quality profile name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "deactivate_rule",
+                    "description": "Deactivate a rule on a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedKey": "profile_key",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "rule",
+                            "description": "Rule key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "squid:AvoidCycles",
+                            "deprecatedKey": "rule_key",
+                            "deprecatedKeySince": "6.5"
+                        }
+                    ]
+                },
+                {
+                    "key": "deactivate_rules",
+                    "description": "Bulk deactivate rules on Quality profiles.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "activation",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "active_severities",
+                            "description": "Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "available_since",
+                            "description": "Filters rules added since date. Format is yyyy-MM-dd",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2014-06-22"
+                        },
+                        {
+                            "key": "cwe",
+                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "12,125,unknown"
+                        },
+                        {
+                            "key": "inheritance",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "INHERITED,OVERRIDES",
+                            "possibleValues": [
+                                "NONE",
+                                "INHERITED",
+                                "OVERRIDES"
+                            ]
+                        },
+                        {
+                            "key": "is_template",
+                            "description": "Filter template rules",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "languages",
+                            "description": "Comma-separated list of languages",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java,js"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "owaspTop10",
+                            "description": "Comma-separated list of OWASP Top 10 lowercase categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "a1",
+                                "a2",
+                                "a3",
+                                "a4",
+                                "a5",
+                                "a6",
+                                "a7",
+                                "a8",
+                                "a9",
+                                "a10"
+                            ]
+                        },
+                        {
+                            "key": "q",
+                            "description": "UTF-8 search query",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "xpath",
+                            "minimumLength": 2
+                        },
+                        {
+                            "key": "qprofile",
+                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "repositories",
+                            "description": "Comma-separated list of repositories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "checkstyle,findbugs"
+                        },
+                        {
+                            "key": "rule_key",
+                            "description": "Key of rule to search for",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid:S001"
+                        },
+                        {
+                            "key": "s",
+                            "description": "Sort field",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "name",
+                            "possibleValues": [
+                                "name",
+                                "updatedAt",
+                                "createdAt",
+                                "key"
+                            ]
+                        },
+                        {
+                            "key": "sansTop25",
+                            "description": "Comma-separated list of SANS Top 25 categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "insecure-interaction",
+                                "risky-resource",
+                                "porous-defenses"
+                            ]
+                        },
+                        {
+                            "key": "severities",
+                            "description": "Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "sonarsourceSecurity",
+                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sql-injection,command-injection,others",
+                            "possibleValues": [
+                                "sql-injection",
+                                "command-injection",
+                                "path-traversal-injection",
+                                "ldap-injection",
+                                "xpath-injection",
+                                "rce",
+                                "dos",
+                                "ssrf",
+                                "csrf",
+                                "xss",
+                                "log-injection",
+                                "http-response-splitting",
+                                "open-redirect",
+                                "xxe",
+                                "object-injection",
+                                "weak-cryptography",
+                                "auth",
+                                "insecure-conf",
+                                "encrypt-data",
+                                "traceability",
+                                "file-manipulation",
+                                "others"
+                            ]
+                        },
+                        {
+                            "key": "statuses",
+                            "description": "Comma-separated list of status codes",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "READY",
+                            "possibleValues": [
+                                "BETA",
+                                "DEPRECATED",
+                                "READY",
+                                "REMOVED"
+                            ]
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,java8"
+                        },
+                        {
+                            "key": "targetKey",
+                            "description": "Quality Profile key on which the rule deactivation is done. To retrieve a profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL1",
+                            "deprecatedKey": "profile_key",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "template_key",
+                            "description": "Key of the template rule to filter on. Used to search for the custom rules based on this template.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java:S001"
+                        },
+                        {
+                            "key": "types",
+                            "description": "Comma-separated list of types. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BUG",
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY",
+                                "SECURITY_HOTSPOT"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete a quality profile and all its descendants. The default quality profile cannot be deleted.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "export",
+                    "description": "Export a quality profile.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "exporterKey",
+                            "description": "Output format. If left empty, the same format as api/qualityprofiles/backup is used. Possible values are described by api/qualityprofiles/exporters.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedKey": "format",
+                            "deprecatedKeySince": "6.3",
+                            "possibleValues": [
+                                "sonarlint-vs-vbnet",
+                                "sonarlint-vs-cs",
+                                "roslyn-vbnet",
+                                "roslyn-cs"
+                            ]
+                        },
+                        {
+                            "key": "key",
+                            "description": "Quality profile key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "terraform",
+                            "possibleValues": [
+                                "abap",
+                                "apex",
+                                "c",
+                                "cloudformation",
+                                "cobol",
+                                "cpp",
+                                "cs",
+                                "css",
+                                "flex",
+                                "go",
+                                "java",
+                                "js",
+                                "json",
+                                "jsp",
+                                "kotlin",
+                                "objc",
+                                "php",
+                                "plsql",
+                                "py",
+                                "ruby",
+                                "scala",
+                                "swift",
+                                "terraform",
+                                "ts",
+                                "tsql",
+                                "vbnet",
+                                "web",
+                                "xml",
+                                "yaml"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name to export. If left empty, the default profile for the language is exported.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "My Sonar way",
+                            "deprecatedKey": "name",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "exporters",
+                    "description": "Lists available profile export formats.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                },
+                {
+                    "key": "importers",
+                    "description": "List supported importers.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                },
+                {
+                    "key": "inheritance",
+                    "description": "Show a quality profile\u0027s ancestors and children.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "projects",
+                    "description": "List projects with their association status regarding a quality profile",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "\u0027more\u0027 response field is deprecated",
+                            "version": "7.2"
+                        },
+                        {
+                            "description": "\u0027id\u0027 response field is deprecated",
+                            "version": "6.5"
+                        },
+                        {
+                            "description": "\u0027uuid\u0027 response field is deprecated and replaced by \u0027id\u0027",
+                            "version": "6.0"
+                        },
+                        {
+                            "description": "\u0027key\u0027 response field has been added to return the project key",
+                            "version": "6.0"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42",
+                            "deprecatedKey": "page",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to projects that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar",
+                            "deprecatedKey": "query",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "selected",
+                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "selected",
+                            "possibleValues": [
+                                "all",
+                                "deselected",
+                                "selected"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_project",
+                    "description": "Remove a project\u0027s association with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "projectKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "projectUuid",
+                            "description": "Project ID. Either this parameter, or \u0027project\u0027 must be set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcB-iU5OvuD2FL6",
+                            "deprecatedSince": "6.5"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "rename",
+                    "description": "Rename a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "name",
+                            "description": "New quality profile name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Sonar way",
+                            "maximumLength": 100
+                        }
+                    ]
+                },
+                {
+                    "key": "restore",
+                    "description": "Restore a quality profile using an XML file. The restored profile name is taken from the backup file, so if a profile with the same name and language already exists, it will be overwritten.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "backup",
+                            "description": "A profile backup file in XML format, as generated by api/qualityprofiles/backup or the former api/profiles/backup.",
+                            "required": true,
+                            "internal": false
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "restore_built_in",
+                    "description": "This web service has no effect since 6.4. It\u0027s no more possible to restore built-in quality profiles because they are automatically updated and read only. Returns HTTP code 410.",
+                    "deprecatedSince": "6.4",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": []
+                },
+                {
+                    "key": "search",
+                    "description": "Search quality profiles",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Add available actions \u0027delete\u0027 and \u0027associateProjects\u0027",
+                            "version": "7.0"
+                        },
+                        {
+                            "description": "Add available actions \u0027edit\u0027, \u0027copy\u0027 and \u0027setAsDefault\u0027 and global action \u0027create\u0027",
+                            "version": "6.6"
+                        },
+                        {
+                            "description": "The parameters \u0027defaults\u0027, \u0027project\u0027 and \u0027language\u0027 can be combined without any constraint",
+                            "version": "6.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "defaults",
+                            "description": "If set to true, return only the quality profiles marked as default for each language",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "language",
+                            "description": "Language key. If provided, only profiles for the given language are returned.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "abap",
+                                "apex",
+                                "c",
+                                "cloudformation",
+                                "cobol",
+                                "cpp",
+                                "cs",
+                                "css",
+                                "flex",
+                                "go",
+                                "java",
+                                "js",
+                                "json",
+                                "jsp",
+                                "kotlin",
+                                "objc",
+                                "php",
+                                "plsql",
+                                "py",
+                                "ruby",
+                                "scala",
+                                "swift",
+                                "terraform",
+                                "ts",
+                                "tsql",
+                                "vbnet",
+                                "web",
+                                "xml",
+                                "yaml"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "projectKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "SonarQube Way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                },
+                {
+                    "key": "set_default",
+                    "description": "Select the default profile for a given language.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "key",
+                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
+                            "deprecatedSince": "6.6",
+                            "deprecatedKey": "profileKey",
+                            "deprecatedKeySince": "6.5"
+                        },
+                        {
+                            "key": "language",
+                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "css",
+                                "scala",
+                                "jsp",
+                                "py",
+                                "js",
+                                "plsql",
+                                "apex",
+                                "java",
+                                "web",
+                                "xml",
+                                "flex",
+                                "json",
+                                "vbnet",
+                                "cloudformation",
+                                "swift",
+                                "yaml",
+                                "cpp",
+                                "c",
+                                "go",
+                                "kotlin",
+                                "tsql",
+                                "ruby",
+                                "cs",
+                                "cobol",
+                                "php",
+                                "terraform",
+                                "abap",
+                                "objc",
+                                "ts"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "qualityProfile",
+                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Sonar way",
+                            "deprecatedKey": "profileName",
+                            "deprecatedKeySince": "6.6"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/rules",
+            "description": "Get and update some details of automatic rules, and manage custom rules.",
+            "actions": [
+                {
+                    "key": "repositories",
+                    "description": "List available rule repositories",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "language",
+                            "description": "A language key; if provided, only repositories for the given language will be returned",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java"
+                        },
+                        {
+                            "key": "q",
+                            "description": "A pattern to match repository keys/names against",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for a collection of relevant rules matching a specified query.\u003cbr/\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The field \u0027updatedAt\u0027 has been added to the \u0027f\u0027 parameter",
+                            "version": "7.5"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "activation",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "active_severities",
+                            "description": "Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "asc",
+                            "description": "Ascending sort",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "true",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "available_since",
+                            "description": "Filters rules added since date. Format is yyyy-MM-dd",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "2014-06-22"
+                        },
+                        {
+                            "key": "cwe",
+                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "12,125,unknown"
+                        },
+                        {
+                            "key": "f",
+                            "description": "Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :\u003cul\u003e\u003cli\u003e\"defaultDebtRemFn\" becomes \"defaultRemFn\"\u003c/li\u003e\u003cli\u003e\"debtRemFn\" becomes \"remFn\"\u003c/li\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "repo,name",
+                            "possibleValues": [
+                                "actives",
+                                "createdAt",
+                                "debtOverloaded",
+                                "debtRemFn",
+                                "defaultDebtRemFn",
+                                "defaultRemFn",
+                                "deprecatedKeys",
+                                "effortToFixDescription",
+                                "gapDescription",
+                                "htmlDesc",
+                                "htmlNote",
+                                "internalKey",
+                                "isExternal",
+                                "isTemplate",
+                                "lang",
+                                "langName",
+                                "mdDesc",
+                                "mdNote",
+                                "name",
+                                "noteLogin",
+                                "params",
+                                "remFn",
+                                "remFnOverloaded",
+                                "repo",
+                                "scope",
+                                "severity",
+                                "status",
+                                "sysTags",
+                                "tags",
+                                "templateKey",
+                                "updatedAt"
+                            ]
+                        },
+                        {
+                            "key": "facets",
+                            "description": "Comma-separated list of the facets to be computed. No facet is computed by default.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "languages,repositories",
+                            "possibleValues": [
+                                "languages",
+                                "repositories",
+                                "tags",
+                                "severities",
+                                "active_severities",
+                                "statuses",
+                                "types",
+                                "true",
+                                "cwe",
+                                "owaspTop10",
+                                "sansTop25",
+                                "sonarsourceSecurity"
+                            ]
+                        },
+                        {
+                            "key": "include_external",
+                            "description": "Include external engine rules in the results",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "inheritance",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "INHERITED,OVERRIDES",
+                            "possibleValues": [
+                                "NONE",
+                                "INHERITED",
+                                "OVERRIDES"
+                            ]
+                        },
+                        {
+                            "key": "is_template",
+                            "description": "Filter template rules",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "languages",
+                            "description": "Comma-separated list of languages",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java,js"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "owaspTop10",
+                            "description": "Comma-separated list of OWASP Top 10 lowercase categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "a1",
+                                "a2",
+                                "a3",
+                                "a4",
+                                "a5",
+                                "a6",
+                                "a7",
+                                "a8",
+                                "a9",
+                                "a10"
+                            ]
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "UTF-8 search query",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "xpath",
+                            "minimumLength": 2
+                        },
+                        {
+                            "key": "qprofile",
+                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "repositories",
+                            "description": "Comma-separated list of repositories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "checkstyle,findbugs"
+                        },
+                        {
+                            "key": "rule_key",
+                            "description": "Key of rule to search for",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid:S001"
+                        },
+                        {
+                            "key": "rule_keys",
+                            "description": "Rule keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "squid:S1002,squid:S1003"
+                        },
+                        {
+                            "key": "s",
+                            "description": "Sort field",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "name",
+                            "possibleValues": [
+                                "name",
+                                "updatedAt",
+                                "createdAt",
+                                "key"
+                            ]
+                        },
+                        {
+                            "key": "sansTop25",
+                            "description": "Comma-separated list of SANS Top 25 categories.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "insecure-interaction",
+                                "risky-resource",
+                                "porous-defenses"
+                            ]
+                        },
+                        {
+                            "key": "severities",
+                            "description": "Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "CRITICAL,BLOCKER",
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "sonarsourceSecurity",
+                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sql-injection,command-injection,others",
+                            "possibleValues": [
+                                "sql-injection",
+                                "command-injection",
+                                "path-traversal-injection",
+                                "ldap-injection",
+                                "xpath-injection",
+                                "rce",
+                                "dos",
+                                "ssrf",
+                                "csrf",
+                                "xss",
+                                "log-injection",
+                                "http-response-splitting",
+                                "open-redirect",
+                                "xxe",
+                                "object-injection",
+                                "weak-cryptography",
+                                "auth",
+                                "insecure-conf",
+                                "encrypt-data",
+                                "traceability",
+                                "file-manipulation",
+                                "others"
+                            ]
+                        },
+                        {
+                            "key": "statuses",
+                            "description": "Comma-separated list of status codes",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "READY",
+                            "possibleValues": [
+                                "BETA",
+                                "DEPRECATED",
+                                "READY",
+                                "REMOVED"
+                            ]
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Comma-separated list of tags. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "security,java8"
+                        },
+                        {
+                            "key": "template_key",
+                            "description": "Key of the template rule to filter on. Used to search for the custom rules based on this template.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java:S001"
+                        },
+                        {
+                            "key": "types",
+                            "description": "Comma-separated list of types. Returned rules match any of the tags (OR operator)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "BUG",
+                            "possibleValues": [
+                                "CODE_SMELL",
+                                "BUG",
+                                "VULNERABILITY",
+                                "SECURITY_HOTSPOT"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "show",
+                    "description": "Get detailed information about a rule\u003cbr\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003eIn 7.1, the field \u0027scope\u0027 has been added.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "actives",
+                            "description": "Show rule\u0027s activations for all profiles (\"active rules\")",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "key",
+                            "description": "Rule key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "javascript:EmptyBlock"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "tags",
+                    "description": "List rule tags",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 100",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "10",
+                            "exampleValue": "20",
+                            "maximumValue": 100
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to tags that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "misra"
+                        }
+                    ]
+                },
+                {
+                    "key": "update",
+                    "description": "Update an existing rule.\u003cbr\u003eRequires the \u0027Administer Quality Profiles\u0027 permission",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "debt_sub_characteristic",
+                            "description": "Debt characteristics are no more supported. This parameter is ignored.",
+                            "required": false,
+                            "internal": false,
+                            "deprecatedSince": "5.5"
+                        },
+                        {
+                            "key": "key",
+                            "description": "Key of the rule to update",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "javascript:NullCheck",
+                            "maximumLength": 200
+                        },
+                        {
+                            "key": "markdown_description",
+                            "description": "Rule description (mandatory for custom rule and manual rule)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Description of my custom rule"
+                        },
+                        {
+                            "key": "markdown_note",
+                            "description": "Optional note in markdown format. Use empty value to remove current note. Note is not changed if the parameter is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my *note*"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Rule name (mandatory for custom rule)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "My custom rule",
+                            "maximumLength": 200
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "params",
+                            "description": "Parameters as semi-colon list of \u003ckey\u003e\u003d\u003cvalue\u003e, for example \u0027params\u003dkey1\u003dv1;key2\u003dv2\u0027 (Only when updating a custom rule)",
+                            "required": false,
+                            "internal": false
+                        },
+                        {
+                            "key": "remediation_fn_base_effort",
+                            "description": "Base effort of the remediation function of the rule",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "1d"
+                        },
+                        {
+                            "key": "remediation_fn_type",
+                            "description": "Type of the remediation function of the rule",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "LINEAR",
+                                "LINEAR_OFFSET",
+                                "CONSTANT_ISSUE"
+                            ]
+                        },
+                        {
+                            "key": "remediation_fy_gap_multiplier",
+                            "description": "Gap multiplier of the remediation function of the rule",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "3min"
+                        },
+                        {
+                            "key": "severity",
+                            "description": "Rule severity (Only when updating a custom rule)",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "INFO",
+                                "MINOR",
+                                "MAJOR",
+                                "CRITICAL",
+                                "BLOCKER"
+                            ]
+                        },
+                        {
+                            "key": "status",
+                            "description": "Rule status (Only when updating a custom rule)",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "BETA",
+                                "DEPRECATED",
+                                "READY",
+                                "REMOVED"
+                            ]
+                        },
+                        {
+                            "key": "tags",
+                            "description": "Optional comma-separated list of tags to set. Use blank value to remove current tags. Tags are not changed if the parameter is not set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "java8,security"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/settings",
+            "description": "Manage settings.",
+            "actions": [
+                {
+                    "key": "list_definitions",
+                    "description": "List settings definitions.\u003cbr\u003eRequires \u0027Browse\u0027 permission when a component is specified\u003cbr/\u003eTo access licensed settings, authentication is required\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "reset",
+                    "description": "Remove a setting value.\u003cbr\u003eThe settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "The settings defined in conf/sonar.properties are read-only and can\u0027t be changed",
+                            "version": "7.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "componentKey",
+                            "deprecatedKeySince": "6.3"
+                        },
+                        {
+                            "key": "keys",
+                            "description": "Comma-separated list of keys",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "sonar.links.scm,sonar.debt.hoursInDay"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        }
+                    ]
+                },
+                {
+                    "key": "set",
+                    "description": "Update a setting value.\u003cbr\u003eEither \u0027value\u0027 or \u0027values\u0027 must be provided.\u003cbr\u003e The settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "The settings defined in conf/sonar.properties are read-only and can\u0027t be changed",
+                            "version": "7.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "deprecatedKey": "componentKey",
+                            "deprecatedKeySince": "6.3"
+                        },
+                        {
+                            "key": "fieldValues",
+                            "description": "Setting field values. To set several values, the parameter must be called once for each value.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "fieldValues\u003d{\"firstField\":\"first value\", \"secondField\":\"second value\", \"thirdField\":\"third value\"}"
+                        },
+                        {
+                            "key": "key",
+                            "description": "Setting key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "sonar.links.scm"
+                        },
+                        {
+                            "key": "value",
+                            "description": "Setting value. To reset a value, please use the reset web service.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "git@github.com:SonarSource/sonarqube.git",
+                            "maximumLength": 4000
+                        },
+                        {
+                            "key": "values",
+                            "description": "Setting multi value. To set several values, the parameter must be called once for each value.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "values\u003dfirstValue\u0026values\u003dsecondValue\u0026values\u003dthirdValue"
+                        }
+                    ]
+                },
+                {
+                    "key": "values",
+                    "description": "List settings values.\u003cbr\u003eIf no value has been set for a setting, then the default value is returned.\u003cbr\u003eThe settings from conf/sonar.properties are excluded from results.\u003cbr\u003eRequires \u0027Browse\u0027 or \u0027Execute Analysis\u0027 permission when a component is specified.\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "version": "7.6"
+                        },
+                        {
+                            "description": "The settings from conf/sonar.properties are excluded from results.",
+                            "version": "7.1"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "component",
+                            "description": "Component key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "keys",
+                            "description": "List of setting keys",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar.test.inclusions,sonar.exclusions"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/sources",
+            "description": "Get details on source files. See also api/tests.",
+            "actions": [
+                {
+                    "key": "raw",
+                    "description": "Get source code as raw text. Require \u0027See Source Code\u0027 permission on file",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "branch",
+                            "description": "Branch key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "key",
+                            "description": "File key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project:src/foo/Bar.php"
+                        },
+                        {
+                            "key": "pullRequest",
+                            "description": "Pull request id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "5461"
+                        }
+                    ]
+                },
+                {
+                    "key": "scm",
+                    "description": "Get SCM information of source files. Require See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eAuthor of the commit\u003c/li\u003e\u003cli\u003eDatetime of the commit (before 5.2 it was only the Date)\u003c/li\u003e\u003cli\u003eRevision of the commit (added in 5.2)\u003c/li\u003e\u003c/ol\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "commits_by_line",
+                            "description": "Group lines by SCM commit if value is false, else display commits for each line, even if two consecutive lines relate to the same commit.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "from",
+                            "description": "First line to return. Starts at 1",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "10"
+                        },
+                        {
+                            "key": "key",
+                            "description": "File key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project:/src/foo/Bar.php"
+                        },
+                        {
+                            "key": "to",
+                            "description": "Last line to return (inclusive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "20"
+                        }
+                    ]
+                },
+                {
+                    "key": "show",
+                    "description": "Get source code. Requires See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eContent of the line\u003c/li\u003e\u003c/ol\u003e",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "from",
+                            "description": "First line to return. Starts at 1",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "10"
+                        },
+                        {
+                            "key": "key",
+                            "description": "File key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project:/src/foo/Bar.php"
+                        },
+                        {
+                            "key": "to",
+                            "description": "Last line to return (inclusive)",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "20"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/timemachine",
+            "description": "Removed since 6.3, please use api/measures/search_history instead",
+            "actions": [
+                {
+                    "key": "index",
+                    "description": "The web service is removed and you\u0027re invited to use api/measures/search_history instead",
+                    "deprecatedSince": "6.3",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                }
+            ]
+        },
+        {
+            "path": "api/user_groups",
+            "description": "Manage user groups.",
+            "actions": [
+                {
+                    "key": "add_user",
+                    "description": "Add a user to a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "It\u0027s no longer possible to add a user to the default group",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Group name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "create",
+                    "description": "Create a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "description",
+                            "description": "Description for the new group. A group description cannot be larger than 200 characters.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default group for new users",
+                            "maximumLength": 200
+                        },
+                        {
+                            "key": "name",
+                            "description": "Name for the new group. A group name cannot be larger than 255 characters and must be unique. The value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "sonar-users",
+                            "maximumLength": 255
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete a group. The default groups cannot be deleted.\u003cbr/\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Group name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "remove_user",
+                    "description": "Remove a user from a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Group name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for user groups.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Paging response fields moved to a Paging object",
+                            "version": "6.4"
+                        },
+                        {
+                            "description": "\u0027default\u0027 response field has been added",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "f",
+                            "description": "Comma-separated list of the fields to be returned in response. All the fields are returned by default.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "name",
+                                "description",
+                                "membersCount"
+                            ]
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to names that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-users"
+                        }
+                    ]
+                },
+                {
+                    "key": "update",
+                    "description": "Update a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [
+                        {
+                            "description": "The default group is no longer editable",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "description",
+                            "description": "New optional description for the group. A group description cannot be larger than 200 characters. If value is not defined, then description is not changed.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Default group for new users",
+                            "maximumLength": 200
+                        },
+                        {
+                            "key": "id",
+                            "description": "Identifier of the group.",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "name",
+                            "description": "New optional name for the group. A group name cannot be larger than 255 characters and must be unique. Value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used. If value is empty or not defined, then name is not changed.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-group",
+                            "maximumLength": 255
+                        }
+                    ]
+                },
+                {
+                    "key": "users",
+                    "description": "Search for users with membership information with respect to a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "id",
+                            "description": "Group id",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Group name",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "sonar-administrators"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Key of organization",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "25",
+                            "exampleValue": "20"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to names or logins that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "freddy"
+                        },
+                        {
+                            "key": "selected",
+                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "selected",
+                            "possibleValues": [
+                                "all",
+                                "deselected",
+                                "selected"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/user_properties",
+            "description": "Removed since 6.3, please use api/favorites and api/notifications instead",
+            "actions": [
+                {
+                    "key": "index",
+                    "description": "This web service is removed",
+                    "deprecatedSince": "6.3",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                }
+            ]
+        },
+        {
+            "path": "api/user_tokens",
+            "description": "List, create, and delete a user\u0027s access tokens.",
+            "actions": [
+                {
+                    "key": "generate",
+                    "description": "Generate a user access token. \u003cbr /\u003ePlease keep your tokens secret. They enable to authenticate and analyze projects.\u003cbr /\u003eIt requires administration permissions to specify a \u0027login\u0027 and generate a token for another user. Otherwise, a token is generated for the current user.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login. If not set, the token is generated for the authenticated user.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Token name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Project scan on Travis",
+                            "maximumLength": 100
+                        }
+                    ]
+                },
+                {
+                    "key": "revoke",
+                    "description": "Revoke a user access token. \u003cbr/\u003eIt requires administration permissions to specify a \u0027login\u0027 and revoke a token for another user. Otherwise, the token for the current user is revoked.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        },
+                        {
+                            "key": "name",
+                            "description": "Token name",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "Project scan on Travis"
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "List the access tokens of a user.\u003cbr\u003eThe login must exist and active.\u003cbr\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user is using a token many times in less than one hour.\u003cbr/It requires administration permissions to specify a \u0027login\u0027 and list the tokens of another user. Otherwise, tokens for the current user are listed.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "New field \u0027lastConnectionDate\u0027 is added to response",
+                            "version": "7.7"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "User login",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "g.hopper"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/users",
+            "description": "Manage users.",
+            "actions": [
+                {
+                    "key": "groups",
+                    "description": "Lists the groups a user belongs to. \u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Paging response fields moved to a Paging object",
+                            "version": "6.4"
+                        },
+                        {
+                            "description": "\u0027default\u0027 response field has been added",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "login",
+                            "description": "A user login",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "admin"
+                        },
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "25",
+                            "exampleValue": "20"
+                        },
+                        {
+                            "key": "q",
+                            "description": "Limit search to group names that contain the supplied string.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "users"
+                        },
+                        {
+                            "key": "selected",
+                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "selected",
+                            "possibleValues": [
+                                "all",
+                                "deselected",
+                                "selected"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Get a list of active users. \u003cbr/\u003eThe following fields are only returned when user has Administer System permission or for logged-in in user :\u003cul\u003e   \u003cli\u003e\u0027email\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalIdentity\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalProvider\u0027\u003c/li\u003e   \u003cli\u003e\u0027groups\u0027\u003c/li\u003e   \u003cli\u003e\u0027lastConnectionDate\u0027\u003c/li\u003e   \u003cli\u003e\u0027tokensCount\u0027\u003c/li\u003e\u003c/ul\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "New field \u0027lastConnectionDate\u0027 is added to response",
+                            "version": "7.7"
+                        },
+                        {
+                            "description": "External identity is only returned to system administrators",
+                            "version": "7.4"
+                        },
+                        {
+                            "description": "Paging response fields moved to a Paging object",
+                            "version": "6.4"
+                        },
+                        {
+                            "description": "Avatar has been added to the response",
+                            "version": "6.4"
+                        },
+                        {
+                            "description": "Email is only returned when user has Administer System permission",
+                            "version": "6.4"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less or equal than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "50",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "q",
+                            "description": "Filter on login, name and email",
+                            "required": false,
+                            "internal": false,
+                            "minimumLength": 2
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/webhooks",
+            "description": "Webhooks allow to notify external services when a project analysis is done",
+            "actions": [
+                {
+                    "key": "create",
+                    "description": "Create a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "name",
+                            "description": "Name displayed in the administration console of webhooks",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Webhook",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "organization",
+                            "description": "The key of the organization that will own the webhook",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org",
+                            "maximumLength": 255
+                        },
+                        {
+                            "key": "project",
+                            "description": "The key of the project that will own the webhook",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "secret",
+                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "your_secret",
+                            "maximumLength": 200,
+                            "minimumLength": 1
+                        },
+                        {
+                            "key": "url",
+                            "description": "Server endpoint that will receive the webhook payload, for example \u0027http://my_server/foo\u0027. If HTTP Basic authentication is used, HTTPS is recommended to avoid man in the middle attacks. Example: \u0027https://myLogin:myPassword@my_server/foo\u0027",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "https://www.google.com/sonar",
+                            "maximumLength": 512
+                        }
+                    ]
+                },
+                {
+                    "key": "delete",
+                    "description": "Delete a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "webhook",
+                            "description": "The key of the webhook to be deleted, auto-generated value can be obtained through api/webhooks/create or api/webhooks/list",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "maximumLength": 40
+                        }
+                    ]
+                },
+                {
+                    "key": "deliveries",
+                    "description": "Get the recent deliveries for a specified project or Compute Engine task.\u003cbr/\u003eRequire \u0027Administer\u0027 permission on the related project.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "ceTaskId",
+                            "description": "Id of the Compute Engine task",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
+                        },
+                        {
+                            "key": "componentKey",
+                            "description": "Key of the project",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my-project"
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0 and less than 500",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "10",
+                            "exampleValue": "20",
+                            "maximumValue": 500
+                        },
+                        {
+                            "key": "webhook",
+                            "description": "Key of the webhook that triggered those deliveries, auto-generated value that can be obtained through api/webhooks/create or api/webhooks/list",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FLz"
+                        }
+                    ]
+                },
+                {
+                    "key": "delivery",
+                    "description": "Get a webhook delivery by its id.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "deliveryId",
+                            "description": "Id of delivery",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL3"
+                        }
+                    ]
+                },
+                {
+                    "key": "list",
+                    "description": "Search for global webhooks or project webhooks. Webhooks are ordered by name.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Field \u0027secret\u0027 added to response",
+                            "version": "7.8"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "organization",
+                            "description": "Organization key",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my-org"
+                        },
+                        {
+                            "key": "project",
+                            "description": "Project key",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        }
+                    ]
+                },
+                {
+                    "key": "update",
+                    "description": "Update a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "name",
+                            "description": "new name of the webhook",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "My Webhook",
+                            "maximumLength": 100
+                        },
+                        {
+                            "key": "secret",
+                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "your_secret",
+                            "maximumLength": 200,
+                            "minimumLength": 1
+                        },
+                        {
+                            "key": "url",
+                            "description": "new url to be called by the webhook",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "https://www.google.com/sonar",
+                            "maximumLength": 512
+                        },
+                        {
+                            "key": "webhook",
+                            "description": "The key of the webhook to be updated, auto-generated value can be obtained through api/webhooks/create or api/webhooks/list",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "my_project",
+                            "maximumLength": 40
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "api/webservices",
+            "description": "Get information on the web api supported on this instance.",
+            "actions": [
+                {
+                    "key": "list",
+                    "description": "List web services",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": []
+                },
+                {
+                    "key": "response_example",
+                    "description": "Display web service response example",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "action",
+                            "description": "Action of the web service",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "search"
+                        },
+                        {
+                            "key": "controller",
+                            "description": "Controller of the web service",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "api/issues"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/gen/webservices.json
+++ b/gen/webservices.json
@@ -14,7 +14,7 @@
                 },
                 {
                     "key": "validate",
-                    "description": "Check credentials.",
+                    "description": "Check credentials. Returns true for anonymous user.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -28,13 +28,13 @@
             "actions": [
                 {
                     "key": "activity",
-                    "description": "Search for tasks.\u003cbr\u003e Either componentId or component can be provided, but not both.\u003cbr\u003e Requires the project administration permission if componentId or component is set.",
+                    "description": "Search for tasks.<br> Either componentId or component can be provided, but not both.<br> Requires the project administration permission if componentId or component is set.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameters \u0027q\u0027 is deprecated",
+                            "description": "The use of module keys in parameters 'q' is deprecated",
                             "version": "7.6"
                         },
                         {
@@ -50,7 +50,7 @@
                             "version": "6.1"
                         },
                         {
-                            "description": "it\u0027s no more possible to specify the page parameter.",
+                            "description": "it's no more possible to specify the page parameter.",
                             "version": "5.5"
                         }
                     ],
@@ -108,7 +108,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003cli\u003etask ids that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003eMust not be set together with componentId",
+                            "description": "Limit search to: <ul><li>component names that contain the supplied string</li><li>component keys that are exactly the same as the supplied string</li><li>task ids that are exactly the same as the supplied string</li></ul>Must not be set together with componentId",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Apache"
@@ -142,14 +142,18 @@
                 },
                 {
                     "key": "activity_status",
-                    "description": "Returns CE activity related metrics.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "description": "Returns CE activity related metrics.<br>Requires 'Administer' permission on the specified project.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "New field \u0027pendingTime\u0027 in response, only included when there are pending tasks",
+                            "description": "New field 'pendingTime' in response, only included when there are pending tasks",
                             "version": "7.8"
+                        },
+                        {
+                            "description": "New field 'inProgress' in response",
+                            "version": "6.6"
                         }
                     ],
                     "params": [
@@ -172,7 +176,7 @@
                 },
                 {
                     "key": "component",
-                    "description": "Get the pending tasks, in-progress tasks and the last executed task of a given component (usually a project).\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component.\u003cbr\u003eEither \u0027componentId\u0027 or \u0027component\u0027 must be provided.",
+                    "description": "Get the pending tasks, in-progress tasks and the last executed task of a given component (usually a project).<br>Requires the following permission: 'Browse' on the specified component.<br>Either 'componentId' or 'component' must be provided.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -210,7 +214,7 @@
                 },
                 {
                     "key": "task",
-                    "description": "Give Compute Engine task details such as type, status, duration and associated component.\u003cbr /\u003eRequires \u0027Execute Analysis\u0027 permission.",
+                    "description": "Give Compute Engine task details such as type, status, duration and associated component.<br />Requires 'Execute Analysis' permission.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -248,7 +252,7 @@
             "actions": [
                 {
                     "key": "search",
-                    "description": "Search for projects. Used to provide the ability to search for any component but this option has been removed and webservice \u0027api/components/tree\u0027 should be used instead for this purpose",
+                    "description": "Search for projects. Used to provide the ability to search for any component but this option has been removed and webservice 'api/components/tree' should be used instead for this purpose",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -280,7 +284,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>component names that contain the supplied string</li><li>component keys that are exactly the same as the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar"
@@ -289,14 +293,14 @@
                 },
                 {
                     "key": "show",
-                    "description": "Returns a component (file, directory, project) and its ancestors. The ancestors are ordered from the parent to the root project. Requires the following permission: \u0027Browse\u0027 on the project of the specified component.",
+                    "description": "Returns a component (file, directory, project) and its ancestors. The ancestors are ordered from the parent to the root project. Requires the following permission: 'Browse' on the project of the specified component.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
-                            "version": "7.6"
+                            "description": "Added isCctIndexed to the response. It is a temporary field that will be removed soon",
+                            "version": "01 Sep, 2023"
                         }
                     ],
                     "params": [
@@ -325,17 +329,17 @@
                 },
                 {
                     "key": "tree",
-                    "description": "Navigate through components based on the chosen strategy.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.",
+                    "description": "Navigate through components based on the chosen strategy.<br>Requires the following permission: 'Browse' on the specified project.<br>When limiting search with the q parameter, directories are not returned.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of \u0027BRC\u0027 as value for parameter \u0027qualifiers\u0027 is deprecated",
+                            "description": "The use of 'BRC' as value for parameter 'qualifiers' is deprecated",
                             "version": "7.6"
                         },
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         }
                     ],
@@ -393,7 +397,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>component names that contain the supplied string</li><li>component keys that are exactly the same as the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "FILE_NAM",
@@ -401,7 +405,7 @@
                         },
                         {
                             "key": "qualifiers",
-                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:<ul><li>BRC - Sub-projects</li><li>DIR - Directories</li><li>FIL - Files</li><li>TRK - Projects</li><li>UTS - Test Files</li></ul>",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -427,7 +431,7 @@
                         },
                         {
                             "key": "strategy",
-                            "description": "Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Strategy to search for base component descendants:<ul><li>children: return the children components of the base component. Grandchildren components are not returned</li><li>all: return all the descendants components of the base component. Grandchildren are returned.</li><li>leaves: return all the descendant components (files, in general) which don't have other children. They are the leaves of the component tree.</li></ul>",
                             "required": false,
                             "internal": false,
                             "defaultValue": "all",
@@ -447,13 +451,13 @@
             "actions": [
                 {
                     "key": "show",
-                    "description": "Get duplications. Require Browse permission on file\u0027s project",
+                    "description": "Get duplications. Require Browse permission on file's project",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The fields \u0027uuid\u0027, \u0027projectUuid\u0027, \u0027subProjectUuid\u0027 are deprecated in the response.",
+                            "description": "The fields 'uuid', 'projectUuid', 'subProjectUuid' are deprecated in the response.",
                             "version": "6.5"
                         }
                     ],
@@ -481,7 +485,7 @@
                         },
                         {
                             "key": "uuid",
-                            "description": "File ID. If provided, \u0027key\u0027 must not be provided.",
+                            "description": "File ID. If provided, 'key' must not be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "584a89f2-8037-4f7b-b82c-8b45d2d63fb2",
@@ -497,21 +501,21 @@
             "actions": [
                 {
                     "key": "add",
-                    "description": "Add a project as favorite for the authenticated user.\u003cbr\u003eOnly 100 components can be added as favorite.\u003cbr\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project.",
+                    "description": "Add a project as favorite for the authenticated user.<br>Only 100 components can be added as favorite.<br>Requires authentication and the following permission: 'Browse' on the project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "It\u0027s no longer possible to have more than 100 favorites by qualifier",
+                            "description": "It's no longer possible to have more than 100 favorites by qualifier",
                             "version": "7.7"
                         },
                         {
-                            "description": "It\u0027s no longer possible to set a directory as favorite",
+                            "description": "It's no longer possible to set a directory as favorite",
                             "version": "7.7"
                         },
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         }
                     ],
@@ -527,13 +531,13 @@
                 },
                 {
                     "key": "remove",
-                    "description": "Remove a component (project, directory, file etc.) as favorite for the authenticated user.\u003cbr\u003eRequires authentication.",
+                    "description": "Remove a component (project, directory, file etc.) as favorite for the authenticated user.<br>Requires authentication.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         }
                     ],
@@ -549,7 +553,7 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search for the authenticated user favorites.\u003cbr\u003eRequires authentication.",
+                    "description": "Search for the authenticated user favorites.<br>Requires authentication.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -582,7 +586,7 @@
             "actions": [
                 {
                     "key": "index",
-                    "description": "The web service is removed and you\u0027re invited to use api/favorites instead",
+                    "description": "The web service is removed and you're invited to use api/favorites instead",
                     "deprecatedSince": "6.3",
                     "internal": false,
                     "post": false,
@@ -592,27 +596,206 @@
             ]
         },
         {
+            "path": "api/hotspots",
+            "description": "Read and update Security Hotspots.",
+            "actions": [
+                {
+                    "key": "change_status",
+                    "description": "Change the status of a Security Hotpot.<br/>Requires the 'Administer Security Hotspot' permission.",
+                    "internal": false,
+                    "post": true,
+                    "hasResponseExample": false,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "comment",
+                            "description": "Comment text.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "This is safe because user input is validated by the calling code"
+                        },
+                        {
+                            "key": "hotspot",
+                            "description": "Key of the Security Hotspot",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL0"
+                        },
+                        {
+                            "key": "resolution",
+                            "description": "Resolution of the Security Hotspot when new status is REVIEWED, otherwise must not be set.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "FIXED",
+                                "SAFE"
+                            ]
+                        },
+                        {
+                            "key": "status",
+                            "description": "New status of the Security Hotspot.",
+                            "required": true,
+                            "internal": false,
+                            "possibleValues": [
+                                "TO_REVIEW",
+                                "REVIEWED"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "search",
+                    "description": "Search for Security Hotpots.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [
+                        {
+                            "description": "Add fields 'rule' and 'textRange' in the response",
+                            "version": "10 May, 2023"
+                        },
+                        {
+                            "description": "Add the 'files' parameter",
+                            "version": "10 May, 2023"
+                        }
+                    ],
+                    "params": [
+                        {
+                            "key": "fileUuids",
+                            "description": "Comma-separated list of file uuids. Returns only hotspots found in those files. If set, 'files' must not be set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "AXAKhxssZ0nocQ78Us1K"
+                        },
+                        {
+                            "key": "files",
+                            "description": "Comma-separated list of file paths. Returns only hotspots found in those files. If set, 'fileUuids' must not be set.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "src/main/java/com/sonarsource/FourthClass.java"
+                        },
+                        {
+                            "key": "hotspots",
+                            "description": "Comma-separated list of Security Hotspot keys. This parameter is required unless projectKey is provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "onlyMine",
+                            "description": "If 'projectKey' is provided, returns only Security Hotspots assigned to the current user",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "p",
+                            "description": "1-based page number",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "1",
+                            "exampleValue": "42"
+                        },
+                        {
+                            "key": "projectKey",
+                            "description": "Key of the project or application. This parameter is required unless hotspots is provided.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "my_project"
+                        },
+                        {
+                            "key": "ps",
+                            "description": "Page size. Must be greater than 0.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "100",
+                            "exampleValue": "20"
+                        },
+                        {
+                            "key": "resolution",
+                            "description": "If 'projectKey' is provided and if status is 'REVIEWED', only Security Hotspots with the specified resolution are returned.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "FIXED",
+                                "SAFE"
+                            ]
+                        },
+                        {
+                            "key": "sinceLeakPeriod",
+                            "description": "If '%s' is provided, only Security Hotspots created since the leak period are returned.",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "possibleValues": [
+                                "true",
+                                "false",
+                                "yes",
+                                "no"
+                            ]
+                        },
+                        {
+                            "key": "status",
+                            "description": "If 'projectKey' is provided, only Security Hotspots with the specified status are returned.",
+                            "required": false,
+                            "internal": false,
+                            "possibleValues": [
+                                "TO_REVIEW",
+                                "REVIEWED"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "show",
+                    "description": "Provides the details of a Security Hotspot.",
+                    "internal": false,
+                    "post": false,
+                    "hasResponseExample": true,
+                    "changelog": [],
+                    "params": [
+                        {
+                            "key": "hotspot",
+                            "description": "Key of the Security Hotspot",
+                            "required": true,
+                            "internal": false,
+                            "exampleValue": "AU-TpxcA-iU5OvuD2FL0"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "api/issues",
             "description": "Read and update issues.",
             "actions": [
                 {
                     "key": "add_comment",
-                    "description": "Add a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "description": "Add a comment.<br/>Requires authentication and the following permission: 'Browse' on the project of the specified issue.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "the response returns the issue with all its details",
-                            "version": "6.3"
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -636,7 +819,7 @@
                             "description": "Comment text",
                             "required": true,
                             "internal": false,
-                            "exampleValue": "Won\u0027t fix because it doesn\u0027t apply to the context"
+                            "exampleValue": "Won't fix because it doesn't apply to the context"
                         }
                     ]
                 },
@@ -648,18 +831,26 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
                         {
                             "key": "assignee",
-                            "description": "Login of the assignee. When not set, it will unassign the issue. Use \u0027_me\u0027 to assign to current user",
+                            "description": "Login of the assignee. When not set, it will unassign the issue. Use '_me' to assign to current user",
                             "required": false,
                             "internal": false,
                             "exampleValue": "admin"
@@ -675,13 +866,13 @@
                 },
                 {
                     "key": "authors",
-                    "description": "Search SCM accounts which match a given query.\u003cbr/\u003eRequires authentication.",
+                    "description": "Search SCM accounts which match a given query.<br/>Requires authentication.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The maximum size of \u0027ps\u0027 is set to 100",
+                            "description": "The maximum size of 'ps' is set to 100",
                             "version": "7.4"
                         }
                     ],
@@ -720,14 +911,22 @@
                 },
                 {
                     "key": "bulk_change",
-                    "description": "Bulk change on issues.\u003cbr/\u003eRequires authentication.",
+                    "description": "Bulk change on issues.<br/>Requires authentication.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "\u0027actions\u0027 parameter is ignored",
-                            "version": "6.3"
+                            "description": "Transition 'wontfix' is now deprecated. Use transition 'accept' instead.",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Transition 'accept' is now supported.",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Parameters 'set_severity' and 'set_type' are now deprecated.",
+                            "version": "07 Aug, 2023"
                         }
                     ],
                     "params": [
@@ -774,8 +973,17 @@
                                 "close",
                                 "setinreview",
                                 "resolveasreviewed",
-                                "resetastoreview"
+                                "resetastoreview",
+                                "accept"
                             ]
+                        },
+                        {
+                            "key": "isFeedback",
+                            "description": "Define if the given comment is a feedback",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false",
+                            "exampleValue": "false"
                         },
                         {
                             "key": "issues",
@@ -811,6 +1019,7 @@
                             "required": false,
                             "internal": false,
                             "exampleValue": "BLOCKER",
+                            "deprecatedSince": "25 Aug, 2023",
                             "deprecatedKey": "set_severity.severity",
                             "deprecatedKeySince": "6.2",
                             "possibleValues": [
@@ -827,6 +1036,7 @@
                             "required": false,
                             "internal": false,
                             "exampleValue": "BUG",
+                            "deprecatedSince": "25 Aug, 2023",
                             "deprecatedKey": "set_type.type",
                             "deprecatedKeySince": "6.2",
                             "possibleValues": [
@@ -840,16 +1050,11 @@
                 },
                 {
                     "key": "changelog",
-                    "description": "Display changelog of an issue.\u003cbr/\u003eRequires the \u0027Browse\u0027 permission on the project of the specified issue.",
+                    "description": "Display changelog of an issue.<br/>Requires the 'Browse' permission on the project of the specified issue.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
-                    "changelog": [
-                        {
-                            "description": "changes on effort is expressed with the raw value in minutes (instead of the duration previously)",
-                            "version": "6.3"
-                        }
-                    ],
+                    "changelog": [],
                     "params": [
                         {
                             "key": "issue",
@@ -862,26 +1067,26 @@
                 },
                 {
                     "key": "delete_comment",
-                    "description": "Delete a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "description": "Delete a comment.<br/>Requires authentication and the following permission: 'Browse' on the project of the specified issue.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
                         },
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "the response returns the issue with all its details",
-                            "version": "6.3"
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "the \u0027key\u0027 parameter is renamed \u0027comment\u0027",
-                            "version": "6.3"
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -898,12 +1103,47 @@
                 },
                 {
                     "key": "do_transition",
-                    "description": "Do workflow transition on an issue. Requires authentication and Browse permission on project.\u003cbr/\u003eThe transitions \u0027wontfix\u0027 and \u0027falsepositive\u0027 require the permission \u0027Administer Issues\u0027.\u003cbr/\u003eThe transitions involving security hotspots require the permission \u0027Administer Security Hotspot\u0027.",
+                    "description": "Do workflow transition on an issue. Requires authentication and Browse permission on project.<br/>The transitions 'accept', 'wontfix', and 'falsepositive' require the permission 'Administer Issues'.<br/>The transitions involving security hotspots require the permission 'Administer Security Hotspot'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
-                    "changelog": [],
+                    "changelog": [
+                        {
+                            "description": "The transition 'wontfix' is deprecated. Please use 'accept' instead.",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Add transition 'accept'.",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
+                        }
+                    ],
                     "params": [
+                        {
+                            "key": "comment",
+                            "description": "Comment text",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "Won't fix because it doesn't apply to the context"
+                        },
+                        {
+                            "key": "isFeedback",
+                            "description": "Define is the given comment is a feedback",
+                            "required": false,
+                            "internal": false,
+                            "defaultValue": "false"
+                        },
                         {
                             "key": "issue",
                             "description": "Issue key",
@@ -926,33 +1166,34 @@
                                 "close",
                                 "setinreview",
                                 "resolveasreviewed",
-                                "resetastoreview"
+                                "resetastoreview",
+                                "accept"
                             ]
                         }
                     ]
                 },
                 {
                     "key": "edit_comment",
-                    "description": "Edit a comment.\u003cbr/\u003eRequires authentication and the following permission: \u0027Browse\u0027 on the project of the specified issue.",
+                    "description": "Edit a comment.<br/>Requires authentication and the following permission: 'Browse' on the project of the specified issue.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "the response returns the issue with all its details",
-                            "version": "6.3"
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "the \u0027key\u0027 parameter has been renamed comment",
-                            "version": "6.3"
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -970,17 +1211,58 @@
                             "description": "Comment text",
                             "required": true,
                             "internal": false,
-                            "exampleValue": "Won\u0027t fix because it doesn\u0027t apply to the context"
+                            "exampleValue": "Won't fix because it doesn't apply to the context"
                         }
                     ]
                 },
                 {
                     "key": "search",
-                    "description": "Search for issues.\u003cbr\u003eRequires the \u0027Browse\u0027 permission on the specified project(s).",
+                    "description": "Search for issues.<br>Requires the 'Browse' permission on the specified project(s).",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
-                    "changelog": [],
+                    "changelog": [
+                        {
+                            "description": "Value 'wontfix' for 'transition' response field is deprecated, use 'accept' instead",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Possible value 'accept' for 'transition' response field has been added",
+                            "version": "19 Dec, 2023"
+                        },
+                        {
+                            "description": "Parameter and facet 'softwareQualities' changed to 'impactSoftwareQualities'",
+                            "version": "03 Oct, 2023"
+                        },
+                        {
+                            "description": "Parameters 'severities', 'types' are now deprecated.",
+                            "version": "25 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Issue flows in the response may contain description and type fields",
+                            "version": "15 May, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
+                        },
+                        {
+                            "description": "New possible value for 'additionalFields' parameter: 'ruleDescriptionContextKey'",
+                            "version": "27 Mar, 2023"
+                        }
+                    ],
                     "params": [
                         {
                             "key": "additionalFields",
@@ -993,6 +1275,7 @@
                                 "languages",
                                 "actionPlans",
                                 "rules",
+                                "ruleDescriptionContextKey",
                                 "transitions",
                                 "actions",
                                 "users"
@@ -1025,7 +1308,7 @@
                         },
                         {
                             "key": "assignees",
-                            "description": "Comma-separated list of assignee logins. The value \u0027__me__\u0027 can be used as a placeholder for user who performs the request",
+                            "description": "Comma-separated list of assignee logins. The value '__me__' can be used as a placeholder for user who performs the request",
                             "required": false,
                             "internal": false,
                             "exampleValue": "admin,usera,__me__"
@@ -1035,15 +1318,7 @@
                             "description": "SCM accounts. To set several values, the parameter must be called once for each value.",
                             "required": false,
                             "internal": false,
-                            "exampleValue": "author\u003dtorvalds@linux-foundation.org\u0026author\u003dlinux@fondation.org"
-                        },
-                        {
-                            "key": "authors",
-                            "description": "This parameter is deprecated, please use \u0027author\u0027 instead",
-                            "required": false,
-                            "internal": false,
-                            "exampleValue": "torvalds@linux-foundation.org",
-                            "deprecatedSince": "7.7"
+                            "exampleValue": "author=torvalds@linux-foundation.org&author=linux@fondation.org"
                         },
                         {
                             "key": "branch",
@@ -1051,6 +1326,19 @@
                             "required": false,
                             "internal": false,
                             "exampleValue": "feature/my_branch"
+                        },
+                        {
+                            "key": "cleanCodeAttributeCategories",
+                            "description": "Comma-separated list of clean code attribute categories.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ADAPTABLE,INTENTIONAL",
+                            "possibleValues": [
+                                "ADAPTABLE",
+                                "CONSISTENT",
+                                "INTENTIONAL",
+                                "RESPONSIBLE"
+                            ]
                         },
                         {
                             "key": "componentKeys",
@@ -1061,7 +1349,7 @@
                         },
                         {
                             "key": "createdAfter",
-                            "description": "To retrieve issues created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided. \u003cbr\u003eIf this parameter is set, createdSince must not be set",
+                            "description": "To retrieve issues created after the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided. <br>If this parameter is set, createdSince must not be set",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -1075,21 +1363,21 @@
                         },
                         {
                             "key": "createdBefore",
-                            "description": "To retrieve issues created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "description": "To retrieve issues created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
                         },
                         {
                             "key": "createdInLast",
-                            "description": "To retrieve issues created during a time span before the current time (exclusive). Accepted units are \u0027y\u0027 for year, \u0027m\u0027 for month, \u0027w\u0027 for week and \u0027d\u0027 for day. If this parameter is set, createdAfter must not be set",
+                            "description": "To retrieve issues created during a time span before the current time (exclusive). Accepted units are 'y' for year, 'm' for month, 'w' for week and 'd' for day. If this parameter is set, createdAfter must not be set",
                             "required": false,
                             "internal": false,
                             "exampleValue": "1m2w (1 month 2 weeks)"
                         },
                         {
                             "key": "cwe",
-                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select issues not associated to any CWE.",
+                            "description": "Comma-separated list of CWE identifiers. Use 'unknown' to select issues not associated to any CWE.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "12,125,unknown"
@@ -1118,10 +1406,10 @@
                                 "assigned_to_me",
                                 "severities",
                                 "statuses",
+                                "issueStatuses",
                                 "resolutions",
                                 "rules",
                                 "assignees",
-                                "authors",
                                 "author",
                                 "directories",
                                 "languages",
@@ -1131,7 +1419,48 @@
                                 "sansTop25",
                                 "cwe",
                                 "createdAt",
-                                "sonarsourceSecurity"
+                                "sonarsourceSecurity",
+                                "impactSoftwareQualities",
+                                "impactSeverities",
+                                "cleanCodeAttributeCategories"
+                            ]
+                        },
+                        {
+                            "key": "impactSeverities",
+                            "description": "Comma-separated list of impact severities.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "HIGH,LOW",
+                            "possibleValues": [
+                                "LOW",
+                                "MEDIUM",
+                                "HIGH"
+                            ]
+                        },
+                        {
+                            "key": "impactSoftwareQualities",
+                            "description": "Comma-separated list of software qualities.",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "MAINTAINABILITY,RELIABILITY",
+                            "possibleValues": [
+                                "MAINTAINABILITY",
+                                "RELIABILITY",
+                                "SECURITY"
+                            ]
+                        },
+                        {
+                            "key": "issueStatuses",
+                            "description": "Comma-separated list of issue statuses",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "OPEN,ACCEPTED",
+                            "possibleValues": [
+                                "OPEN",
+                                "CONFIRMED",
+                                "FALSE_POSITIVE",
+                                "ACCEPTED",
+                                "FIXED"
                             ]
                         },
                         {
@@ -1150,7 +1479,7 @@
                         },
                         {
                             "key": "onComponentOnly",
-                            "description": "Return only issues at a component\u0027s level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.",
+                            "description": "Return only issues at a component's level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.",
                             "required": false,
                             "internal": false,
                             "defaultValue": "false",
@@ -1237,7 +1566,7 @@
                         },
                         {
                             "key": "rules",
-                            "description": "Comma-separated list of coding rule keys. Format is \u0026lt;repository\u0026gt;:\u0026lt;rule\u0026gt;",
+                            "description": "Comma-separated list of coding rule keys. Format is &lt;repository&gt;:&lt;rule&gt;",
                             "required": false,
                             "internal": false,
                             "exampleValue": "squid:AvoidCycles"
@@ -1248,14 +1577,14 @@
                             "required": false,
                             "internal": false,
                             "possibleValues": [
-                                "CREATION_DATE",
-                                "UPDATE_DATE",
-                                "CLOSE_DATE",
-                                "ASSIGNEE",
-                                "SEVERITY",
                                 "STATUS",
+                                "ASSIGNEE",
+                                "CREATION_DATE",
+                                "SEVERITY",
                                 "FILE_LINE",
-                                "HOTSPOTS"
+                                "HOTSPOTS",
+                                "CLOSE_DATE",
+                                "UPDATE_DATE"
                             ]
                         },
                         {
@@ -1275,6 +1604,7 @@
                             "required": false,
                             "internal": false,
                             "exampleValue": "BLOCKER,CRITICAL",
+                            "deprecatedSince": "25 Aug, 2023",
                             "possibleValues": [
                                 "INFO",
                                 "MINOR",
@@ -1285,7 +1615,7 @@
                         },
                         {
                             "key": "sinceLeakPeriod",
-                            "description": "To retrieve issues created since the leak period.\u003cbr\u003eIf this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.",
+                            "description": "To retrieve issues created since the leak period.<br>If this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.",
                             "required": false,
                             "internal": false,
                             "defaultValue": "false",
@@ -1298,10 +1628,12 @@
                         },
                         {
                             "key": "sonarsourceSecurity",
-                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select issues not associated with any category",
+                            "description": "Comma-separated list of SonarSource security categories. Use 'others' to select issues not associated with any category",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "buffer-overflow",
+                                "permission",
                                 "sql-injection",
                                 "command-injection",
                                 "path-traversal-injection",
@@ -1327,20 +1659,6 @@
                             ]
                         },
                         {
-                            "key": "statuses",
-                            "description": "Comma-separated list of statuses",
-                            "required": false,
-                            "internal": false,
-                            "exampleValue": "OPEN,REOPENED",
-                            "possibleValues": [
-                                "OPEN",
-                                "CONFIRMED",
-                                "REOPENED",
-                                "RESOLVED",
-                                "CLOSED"
-                            ]
-                        },
-                        {
                             "key": "tags",
                             "description": "Comma-separated list of tags.",
                             "required": false,
@@ -1353,6 +1671,7 @@
                             "required": false,
                             "internal": false,
                             "exampleValue": "CODE_SMELL,BUG",
+                            "deprecatedSince": "25 Aug, 2023",
                             "possibleValues": [
                                 "CODE_SMELL",
                                 "BUG",
@@ -1363,18 +1682,31 @@
                 },
                 {
                     "key": "set_severity",
-                    "description": "Change severity.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Change severity.<br/>Requires the following permissions:<ul>  <li>'Authentication'</li>  <li>'Browse' rights on project of the specified issue</li>  <li>'Administer Issues' rights on project of the specified issue</li></ul>",
+                    "deprecatedSince": "25 Aug, 2023",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "This endpoint is now deprecated",
+                            "version": "25 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -1402,22 +1734,26 @@
                 },
                 {
                     "key": "set_tags",
-                    "description": "Set tags on an issue. \u003cbr/\u003eRequires authentication and Browse permission on project",
+                    "description": "Set tags on an issue. <br/>Requires authentication and Browse permission on project",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
                         },
                         {
-                            "description": "response contains issue information instead of list of tags",
-                            "version": "6.4"
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -1441,18 +1777,31 @@
                 },
                 {
                     "key": "set_type",
-                    "description": "Change type of issue, for instance from \u0027code smell\u0027 to \u0027bug\u0027.\u003cbr/\u003eRequires the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Authentication\u0027\u003c/li\u003e  \u003cli\u003e\u0027Browse\u0027 rights on project of the specified issue\u003c/li\u003e  \u003cli\u003e\u0027Administer Issues\u0027 rights on project of the specified issue\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Change type of issue, for instance from 'code smell' to 'bug'.<br/>Requires the following permissions:<ul>  <li>'Authentication'</li>  <li>'Browse' rights on project of the specified issue</li>  <li>'Administer Issues' rights on project of the specified issue</li></ul>",
+                    "deprecatedSince": "25 Aug, 2023",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "the database ids of the components are removed from the response",
-                            "version": "6.5"
+                            "description": "This endpoint is now deprecated",
+                            "version": "25 Aug, 2023"
                         },
                         {
-                            "description": "the response field components.uuid is deprecated. Use components.key instead.",
-                            "version": "6.5"
+                            "description": "Response field 'impacts' added",
+                            "version": "07 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "03 Aug, 2023"
+                        },
+                        {
+                            "description": "Response field 'ruleDescriptionContextKey' added",
+                            "version": "27 Mar, 2023"
                         }
                     ],
                     "params": [
@@ -1484,7 +1833,7 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "Result doesn\u0027t include rules tags anymore",
+                            "description": "Result doesn't include rules tags anymore",
                             "version": "7.4"
                         }
                     ],
@@ -1560,13 +1909,13 @@
             "actions": [
                 {
                     "key": "component",
-                    "description": "Return component with specified measures. The componentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the project of specified component.",
+                    "description": "Return component with specified measures. The componentId or the component parameter must be provided.<br>Requires the following permission: 'Browse' on the project of specified component.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         },
                         {
@@ -1646,18 +1995,22 @@
                 },
                 {
                     "key": "component_tree",
-                    "description": "Navigate through components based on the chosen strategy with specified measures. The baseComponentId or the component parameter must be provided.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project.\u003cbr\u003eWhen limiting search with the q parameter, directories are not returned.",
+                    "description": "Navigate through components based on the chosen strategy with specified measures. The baseComponentId or the component parameter must be provided.<br>Requires the following permission: 'Browse' on the specified project.<br>When limiting search with the q parameter, directories are not returned.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         },
                         {
-                            "description": "field \u0027bestValue\u0027 is added to the response",
+                            "description": "field 'bestValue' is added to the response",
                             "version": "7.2"
+                        },
+                        {
+                            "description": "Number of metric keys is limited to 15",
+                            "version": "6.3"
                         },
                         {
                             "description": "the response field id is deprecated. Use key instead.",
@@ -1666,10 +2019,6 @@
                         {
                             "description": "the response field refId is deprecated. Use refKey instead.",
                             "version": "6.6"
-                        },
-                        {
-                            "description": "Number of metric keys is limited to 15",
-                            "version": "6.3"
                         }
                     ],
                     "params": [
@@ -1745,7 +2094,7 @@
                         },
                         {
                             "key": "metricPeriodSort",
-                            "description": "Sort measures by leak period or not ?. The \u0027s\u0027 parameter must contain the \u0027metricPeriod\u0027 value.",
+                            "description": "Sort measures by leak period or not ?. The 's' parameter must contain the 'metricPeriod' value.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -1754,14 +2103,14 @@
                         },
                         {
                             "key": "metricSort",
-                            "description": "Metric key to sort by. The \u0027s\u0027 parameter must contain the \u0027metric\u0027 or \u0027metricPeriod\u0027 value. It must be part of the \u0027metricKeys\u0027 parameter",
+                            "description": "Metric key to sort by. The 's' parameter must contain the 'metric' or 'metricPeriod' value. It must be part of the 'metricKeys' parameter",
                             "required": false,
                             "internal": false,
                             "exampleValue": "ncloc"
                         },
                         {
                             "key": "metricSortFilter",
-                            "description": "Filter components. Sort must be on a metric. Possible values are: \u003cul\u003e\u003cli\u003eall: return all components\u003c/li\u003e\u003cli\u003ewithMeasuresOnly: filter out components that do not have a measure on the sorted metric\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Filter components. Sort must be on a metric. Possible values are: <ul><li>all: return all components</li><li>withMeasuresOnly: filter out components that do not have a measure on the sorted metric</li></ul>",
                             "required": false,
                             "internal": false,
                             "defaultValue": "all",
@@ -1796,7 +2145,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>component names that contain the supplied string</li><li>component keys that are exactly the same as the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "FILE_NAM",
@@ -1804,7 +2153,7 @@
                         },
                         {
                             "key": "qualifiers",
-                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eBRC - Sub-projects\u003c/li\u003e\u003cli\u003eDIR - Directories\u003c/li\u003e\u003cli\u003eFIL - Files\u003c/li\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003cli\u003eUTS - Test Files\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:<ul><li>BRC - Sub-projects</li><li>DIR - Directories</li><li>FIL - Files</li><li>TRK - Projects</li><li>UTS - Test Files</li></ul>",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -1832,27 +2181,27 @@
                         },
                         {
                             "key": "strategy",
-                            "description": "Strategy to search for base component descendants:\u003cul\u003e\u003cli\u003echildren: return the children components of the base component. Grandchildren components are not returned\u003c/li\u003e\u003cli\u003eall: return all the descendants components of the base component. Grandchildren are returned.\u003c/li\u003e\u003cli\u003eleaves: return all the descendant components (files, in general) which don\u0027t have other children. They are the leaves of the component tree.\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Strategy to search for base component descendants:<ul><li>children: return the children components of the base component. Grandchildren components are not returned</li><li>all: return all the descendants components of the base component. Grandchildren are returned.</li><li>leaves: return all the descendant components (files, in general) which don't have other children. They are the leaves of the component tree.</li></ul>",
                             "required": false,
                             "internal": false,
                             "defaultValue": "all",
                             "possibleValues": [
-                                "all",
+                                "leaves",
                                 "children",
-                                "leaves"
+                                "all"
                             ]
                         }
                     ]
                 },
                 {
                     "key": "search_history",
-                    "description": "Search measures history of a component.\u003cbr\u003eMeasures are ordered chronologically.\u003cbr\u003ePagination applies to the number of measures for each metric.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified component",
+                    "description": "Search measures history of a component.<br>Measures are ordered chronologically.<br>Pagination applies to the number of measures for each metric.<br>Requires the following permission: 'Browse' on the specified component",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         }
                     ],
@@ -1873,7 +2222,7 @@
                         },
                         {
                             "key": "from",
-                            "description": "Filter measures created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "description": "Filter measures created after the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -1911,7 +2260,7 @@
                         },
                         {
                             "key": "to",
-                            "description": "Filter measures created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "description": "Filter measures created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -1992,7 +2341,7 @@
             "actions": [
                 {
                     "key": "add",
-                    "description": "Add a notification for the authenticated user.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e \u003cli\u003eAuthentication if no login is provided. If a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e \u003cli\u003eIf a project is provided, requires the \u0027Browse\u0027 permission on the specified project.\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Add a notification for the authenticated user.<br>Requires one of the following permissions:<ul> <li>Authentication if no login is provided. If a project is provided, requires the 'Browse' permission on the specified project.</li> <li>If a project is provided, requires the 'Browse' permission on the specified project.</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2023,7 +2372,7 @@
                         },
                         {
                             "key": "type",
-                            "description": "Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Notification type. Possible values are for:<ul>  <li>Global notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues</li>  <li>Per project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues</li></ul>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "SQ-MyNewIssues"
@@ -2079,7 +2428,7 @@
                         },
                         {
                             "key": "type",
-                            "description": "Notification type. Possible values are for:\u003cul\u003e  \u003cli\u003eGlobal notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues\u003c/li\u003e  \u003cli\u003ePer project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Notification type. Possible values are for:<ul>  <li>Global notifications: CeReportTaskFailure, ChangesOnMyIssue, SQ-MyNewIssues</li>  <li>Per project notifications: CeReportTaskFailure, ChangesOnMyIssue, NewAlerts, NewFalsePositiveIssue, NewIssues, SQ-MyNewIssues</li></ul>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "SQ-MyNewIssues"
@@ -2094,7 +2443,7 @@
             "actions": [
                 {
                     "key": "add_group",
-                    "description": "Add permission to a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group name or group id must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Add permission to a group.<br /> This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.<br /> The group name or group id must be provided. <br />Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2109,7 +2458,7 @@
                         },
                         {
                             "key": "groupName",
-                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "description": "Group name or 'anyone' (case insensitive)",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar-administrators"
@@ -2123,7 +2472,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning</li><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false
                         },
@@ -2145,7 +2494,7 @@
                 },
                 {
                     "key": "add_group_to_template",
-                    "description": "Add a group to a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Add a group to a permission template.<br /> The group id or group name must be provided. <br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2160,7 +2509,7 @@
                         },
                         {
                             "key": "groupName",
-                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "description": "Group name or 'anyone' (case insensitive)",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar-administrators"
@@ -2174,7 +2523,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2204,7 +2553,7 @@
                 },
                 {
                     "key": "add_project_creator_to_template",
-                    "description": "Add a project creator to a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Add a project creator to a permission template.<br>Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2219,7 +2568,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2249,7 +2598,7 @@
                 },
                 {
                     "key": "add_user",
-                    "description": "Add permission to a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Add permission to a user.<br /> This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.<br />Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2276,7 +2625,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning</li><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false
                         },
@@ -2298,7 +2647,7 @@
                 },
                 {
                     "key": "add_user_to_template",
-                    "description": "Add a user to a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Add a user to a permission template.<br /> Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2320,7 +2669,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2350,7 +2699,7 @@
                 },
                 {
                     "key": "apply_template",
-                    "description": "Apply a permission template to one project.\u003cbr\u003eThe project id or project key must be provided.\u003cbr\u003eThe template id or name must be provided.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Apply a permission template to one project.<br>The project id or project key must be provided.<br>The template id or name must be provided.<br>Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2395,7 +2744,7 @@
                 },
                 {
                     "key": "bulk_apply_template",
-                    "description": "Apply a permission template to several projects.\u003cbr /\u003eThe template id or name must be provided.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Apply a permission template to several projects.<br />The template id or name must be provided.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2408,7 +2757,7 @@
                     "params": [
                         {
                             "key": "analyzedBefore",
-                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).<br> Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -2443,14 +2792,14 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>project names that contain the supplied string</li><li>project keys that are exactly the same as the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "apac"
                         },
                         {
                             "key": "qualifiers",
-                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Comma-separated list of component qualifiers. Filter the results with the specified qualifiers. Possible values are:<ul><li>TRK - Projects</li></ul>",
                             "required": false,
                             "internal": false,
                             "defaultValue": "TRK",
@@ -2478,7 +2827,7 @@
                 },
                 {
                     "key": "create_template",
-                    "description": "Create a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Create a permission template.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -2500,8 +2849,8 @@
                         },
                         {
                             "key": "organization",
-                            "description": "Key of organization, used when group name is set",
-                            "required": false,
+                            "description": "Key of organization",
+                            "required": true,
                             "internal": false,
                             "exampleValue": "my-org"
                         },
@@ -2516,7 +2865,7 @@
                 },
                 {
                     "key": "delete_template",
-                    "description": "Delete a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Delete a permission template.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2547,7 +2896,7 @@
                 },
                 {
                     "key": "remove_group",
-                    "description": "Remove a permission from a group.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e The group id or group name must be provided, not both.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Remove a permission from a group.<br /> This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.<br /> The group id or group name must be provided, not both.<br />Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2562,7 +2911,7 @@
                         },
                         {
                             "key": "groupName",
-                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "description": "Group name or 'anyone' (case insensitive)",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar-administrators"
@@ -2576,7 +2925,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning</li><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false
                         },
@@ -2598,7 +2947,7 @@
                 },
                 {
                     "key": "remove_group_from_template",
-                    "description": "Remove a group from a permission template.\u003cbr /\u003e The group id or group name must be provided. \u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Remove a group from a permission template.<br /> The group id or group name must be provided. <br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2613,7 +2962,7 @@
                         },
                         {
                             "key": "groupName",
-                            "description": "Group name or \u0027anyone\u0027 (case insensitive)",
+                            "description": "Group name or 'anyone' (case insensitive)",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar-administrators"
@@ -2627,7 +2976,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2657,7 +3006,7 @@
                 },
                 {
                     "key": "remove_project_creator_from_template",
-                    "description": "Remove a project creator from a permission template.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Remove a project creator from a permission template.<br>Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2672,7 +3021,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2702,7 +3051,7 @@
                 },
                 {
                     "key": "remove_user",
-                    "description": "Remove permission from a user.\u003cbr /\u003e This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Remove permission from a user.<br /> This service defaults to global permissions, but can be limited to project permissions by providing project id or project key.<br /> Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2724,7 +3073,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning\u003c/li\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for global permissions: admin, profileadmin, gateadmin, scan, provisioning</li><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false
                         },
@@ -2746,7 +3095,7 @@
                 },
                 {
                     "key": "remove_user_from_template",
-                    "description": "Remove a user from a permission template.\u003cbr /\u003e Requires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Remove a user from a permission template.<br /> Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2768,7 +3117,7 @@
                         },
                         {
                             "key": "permission",
-                            "description": "Permission\u003cul\u003e\u003cli\u003ePossible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Permission<ul><li>Possible values for project permissions admin, codeviewer, issueadmin, securityhotspotadmin, scan, user</li></ul>",
                             "required": true,
                             "internal": false,
                             "possibleValues": [
@@ -2798,7 +3147,7 @@
                 },
                 {
                     "key": "search_global_permissions",
-                    "description": "List global permissions. \u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027",
+                    "description": "List global permissions. <br />Requires the following permission: 'Administer System'",
                     "deprecatedSince": "6.5",
                     "internal": false,
                     "post": false,
@@ -2816,7 +3165,7 @@
                 },
                 {
                     "key": "search_project_permissions",
-                    "description": "List project permissions. A project can be a technical project, a view or a developer.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "List project permissions. A project can be a technical project, a view or a developer.<br />Requires the permission 'Administer' on the specified project.",
                     "deprecatedSince": "6.5",
                     "internal": false,
                     "post": false,
@@ -2855,14 +3204,14 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003eproject names that contain the supplied string\u003c/li\u003e\u003cli\u003eproject keys that are exactly the same as the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>project names that contain the supplied string</li><li>project keys that are exactly the same as the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "apac"
                         },
                         {
                             "key": "qualifier",
-                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:<ul><li>TRK - Projects</li></ul>",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -2873,7 +3222,7 @@
                 },
                 {
                     "key": "search_templates",
-                    "description": "List permission templates.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "List permission templates.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": false,
@@ -2881,8 +3230,8 @@
                     "params": [
                         {
                             "key": "organization",
-                            "description": "Key of organization, used when group name is set",
-                            "required": false,
+                            "description": "Key of organization",
+                            "required": true,
                             "internal": false,
                             "exampleValue": "my-org"
                         },
@@ -2897,7 +3246,7 @@
                 },
                 {
                     "key": "set_default_template",
-                    "description": "Set a permission template as default.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Set a permission template as default.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -2912,7 +3261,7 @@
                         },
                         {
                             "key": "qualifier",
-                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:\u003cul\u003e\u003cli\u003eTRK - Projects\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Project qualifier. Filter the results with the specified qualifier. Possible values are:<ul><li>TRK - Projects</li></ul>",
                             "required": false,
                             "internal": false,
                             "defaultValue": "TRK",
@@ -2938,7 +3287,7 @@
                 },
                 {
                     "key": "update_template",
-                    "description": "Update a permission template.\u003cbr /\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Update a permission template.<br />Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -2982,7 +3331,7 @@
             "actions": [
                 {
                     "key": "create_event",
-                    "description": "Create a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be created.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Create a project analysis event.<br>Only event of category 'VERSION' and 'OTHER' can be created.<br>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -3018,7 +3367,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete a project analysis.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the project of the specified analysis.",
+                    "description": "Delete a project analysis.<br>Requires the permission 'Administer' on the project of the specified analysis.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3035,7 +3384,7 @@
                 },
                 {
                     "key": "delete_event",
-                    "description": "Delete a project analysis event.\u003cbr\u003eOnly event of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be deleted.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Delete a project analysis event.<br>Only event of category 'VERSION' and 'OTHER' can be deleted.<br>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3052,7 +3401,7 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search a project analyses and attached events.\u003cbr\u003eRequires the following permission: \u0027Browse\u0027 on the specified project",
+                    "description": "Search a project analyses and attached events.<br>Requires the following permission: 'Browse' on the specified project",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3086,7 +3435,7 @@
                         },
                         {
                             "key": "from",
-                            "description": "Filter analyses created after the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "description": "Filter analyses created after the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2013-05-01"
@@ -3117,7 +3466,7 @@
                         },
                         {
                             "key": "to",
-                            "description": "Filter analyses created before the given date (inclusive). \u003cbr\u003eEither a date (server timezone) or datetime can be provided",
+                            "description": "Filter analyses created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -3126,7 +3475,7 @@
                 },
                 {
                     "key": "set_baseline",
-                    "description": "Set an analysis as the baseline of the New Code Period on a project or a long-lived branch.\u003cbr/\u003eThis manually set baseline overrides the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Set an analysis as the baseline of the New Code Period on a project or a long-lived branch.<br/>This manually set baseline overrides the `sonar.leak.period` setting.<br/>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3155,7 +3504,7 @@
                 },
                 {
                     "key": "unset_baseline",
-                    "description": "Unset any manually-set New Code Period baseline on a project or a long-lived branch.\u003cbr/\u003eUnsetting a manual baseline restores the use of the `sonar.leak.period` setting.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Unset any manually-set New Code Period baseline on a project or a long-lived branch.<br/>Unsetting a manual baseline restores the use of the `sonar.leak.period` setting.<br/>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3177,7 +3526,7 @@
                 },
                 {
                     "key": "update_event",
-                    "description": "Update a project analysis event.\u003cbr\u003eOnly events of category \u0027VERSION\u0027 and \u0027OTHER\u0027 can be updated.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Update a project analysis event.<br>Only events of category 'VERSION' and 'OTHER' can be updated.<br>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -3208,7 +3557,7 @@
             "actions": [
                 {
                     "key": "measure",
-                    "description": "Generate badge for project\u0027s measure as an SVG.\u003cbr/\u003eRequires a security token for private projects.",
+                    "description": "Generate badge for project's measure as an SVG.<br/>Requires a security token for private projects.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3227,17 +3576,17 @@
                             "required": true,
                             "internal": false,
                             "possibleValues": [
-                                "bugs",
                                 "code_smells",
-                                "coverage",
-                                "duplicated_lines_density",
                                 "ncloc",
-                                "sqale_rating",
+                                "coverage",
+                                "sqale_index",
                                 "alert_status",
                                 "reliability_rating",
+                                "duplicated_lines_density",
+                                "vulnerabilities",
+                                "bugs",
                                 "security_rating",
-                                "sqale_index",
-                                "vulnerabilities"
+                                "sqale_rating"
                             ]
                         },
                         {
@@ -3257,7 +3606,7 @@
                 },
                 {
                     "key": "quality_gate",
-                    "description": "Generate badge for project\u0027s quality gate as an SVG.\u003cbr/\u003eRequires a security token for private projects.",
+                    "description": "Generate badge for project's quality gate as an SVG.<br/>Requires a security token for private projects.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3293,7 +3642,7 @@
             "actions": [
                 {
                     "key": "delete",
-                    "description": "Delete a non-main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.",
+                    "description": "Delete a non-main branch of a project.<br/>Requires 'Administer' rights on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3317,7 +3666,7 @@
                 },
                 {
                     "key": "list",
-                    "description": "List the branches of a project.\u003cbr/\u003eRequires \u0027Browse\u0027 or \u0027Execute analysis\u0027 rights on the specified project.",
+                    "description": "List the branches of a project.<br/>The statistics are the overall counts on long branches, and the count of issues detected on the changed code on short branches.Requires 'Browse' or 'Execute analysis' rights on the specified project.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3339,7 +3688,7 @@
                 },
                 {
                     "key": "rename",
-                    "description": "Rename the main branch of a project.\u003cbr/\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "description": "Rename the main branch of a project.<br/>Requires 'Administer' permission on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3370,7 +3719,7 @@
             "actions": [
                 {
                     "key": "create",
-                    "description": "Create a new project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "description": "Create a new project link.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -3410,7 +3759,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete existing project link.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "description": "Delete existing project link.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3427,7 +3776,7 @@
                 },
                 {
                     "key": "search",
-                    "description": "List links of a project.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "List links of a project.<br>The 'projectId' or 'projectKey' must be provided.<br>Requires one of the following permissions:<ul><li>'Administer' rights on the specified project</li><li>'Browse' on the specified project</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3457,7 +3806,7 @@
             "actions": [
                 {
                     "key": "delete",
-                    "description": "Delete a pull request.\u003cbr/\u003eRequires \u0027Administer\u0027 rights on the specified project.",
+                    "description": "Delete a pull request.<br/>Requires 'Administer' rights on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3481,7 +3830,7 @@
                 },
                 {
                     "key": "list",
-                    "description": "List the pull requests of a project.\u003cbr/\u003eOne of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Browse\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Execute Analysis\u0027 rights on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "List the pull requests of a project.<br/>One of the following permissions is required: <ul><li>'Browse' rights on the specified project</li><li>'Execute Analysis' rights on the specified project</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3530,7 +3879,7 @@
                 },
                 {
                     "key": "set",
-                    "description": "Set tags on a project.\u003cbr\u003eRequires the following permission: \u0027Administer\u0027 rights on the specified project",
+                    "description": "Set tags on a project.<br>Requires the following permission: 'Administer' rights on the specified project",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3560,7 +3909,7 @@
             "actions": [
                 {
                     "key": "bulk_delete",
-                    "description": "Delete one or several projects.\u003cbr /\u003eOnly the 1\u0027000 first items in project filters are taken into account.\u003cbr /\u003eRequires \u0027Administer System\u0027 permission.\u003cbr /\u003eAt least one parameter is required among analyzedBefore, projects and q",
+                    "description": "Delete one or several projects.<br />Only the 1'000 first items in project filters are taken into account.<br />Requires 'Administer System' permission.<br />At least one parameter is required among analyzedBefore, projects and q",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3573,7 +3922,7 @@
                     "params": [
                         {
                             "key": "analyzedBefore",
-                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).<br> Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -3606,7 +3955,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit to: <ul><li>component names that contain the supplied string</li><li>component keys that contain the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar"
@@ -3626,7 +3975,7 @@
                 },
                 {
                     "key": "bulk_update_key",
-                    "description": "Bulk update a project or module key and all its sub-components keys. The bulk update allows to replace a part of the current key by another string on the current project and all its sub-modules.\u003cbr\u003eIt\u0027s possible to simulate the bulk update by setting the parameter \u0027dryRun\u0027 at true. No key is updated with a dry run.\u003cbr\u003eEx: to rename a project with key \u0027my_project\u0027 to \u0027my_new_project\u0027 and all its sub-components keys, call the WS with parameters:\u003cul\u003e  \u003cli\u003eproject: my_project\u003c/li\u003e  \u003cli\u003efrom: my_\u003c/li\u003e  \u003cli\u003eto: my_new_\u003c/li\u003e\u003c/ul\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Bulk update a project or module key and all its sub-components keys. The bulk update allows to replace a part of the current key by another string on the current project and all its sub-modules.<br>It's possible to simulate the bulk update by setting the parameter 'dryRun' at true. No key is updated with a dry run.<br>Ex: to rename a project with key 'my_project' to 'my_new_project' and all its sub-components keys, call the WS with parameters:<ul>  <li>project: my_project</li>  <li>from: my_</li>  <li>to: my_new_</li></ul>Requires the permission 'Administer' on the specified project.",
                     "deprecatedSince": "7.6",
                     "internal": false,
                     "post": true,
@@ -3671,20 +4020,20 @@
                 },
                 {
                     "key": "create",
-                    "description": "Create a project.\u003cbr/\u003eRequires \u0027Create Projects\u0027 permission",
+                    "description": "Create a project.<br/>Requires 'Create Projects' permission",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The \u0027visibility\u0027 parameter is public",
+                            "description": "The 'visibility' parameter is public",
                             "version": "7.1"
                         }
                     ],
                     "params": [
                         {
                             "key": "branch",
-                            "description": "SCM Branch of the project. The key of the project will become key:branch, for instance \u0027SonarQube:branch-5.0\u0027",
+                            "description": "SCM Branch of the project. The key of the project will become key:branch, for instance 'SonarQube:branch-5.0'",
                             "required": false,
                             "internal": false,
                             "exampleValue": "branch-5.0",
@@ -3696,6 +4045,20 @@
                             "required": true,
                             "internal": false,
                             "exampleValue": "SonarQube"
+                        },
+                        {
+                            "key": "newCodeDefinitionType",
+                            "description": "Project New Code Definition Type<br/><br/>New code definitions of the following types are allowed:<ul><li>previous_version</li><li>days</li><li>date</li><li>version</li></ul>",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "days"
+                        },
+                        {
+                            "key": "newCodeDefinitionValue",
+                            "description": "Project New Code Definition Value<br/><br/>For each new code definition type, a different value is expected:<ul><li>value is 'previous_version', when the new code definition type is previous_version</li><li>value should be a date <YYYY-MM-DD>, when the new code definition type is date</li><li>value should be version string, when the new code definition type is version</li><li>value should be a number between 1 and 90, when the new code definition type is days</li></ul>",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "30"
                         },
                         {
                             "key": "organization",
@@ -3713,7 +4076,7 @@
                         },
                         {
                             "key": "visibility",
-                            "description": "Whether the created project should be visible to everyone, or only specific user/groups.\u003cbr/\u003eIf no visibility is specified, the default project visibility of the organization will be used.",
+                            "description": "Whether the created project should be visible to everyone, or only specific user/groups.<br/>If no visibility is specified, the default project visibility of the organization will be used.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -3725,7 +4088,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete a project.\u003cbr\u003e Requires \u0027Administer System\u0027 permission or \u0027Administer\u0027 permission on the project.",
+                    "description": "Delete a project.<br> Requires 'Administer System' permission or 'Administer' permission on the project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3742,7 +4105,7 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search for projects to administrate them.\u003cbr\u003eRequires \u0027System Administrator\u0027 permission",
+                    "description": "Search for projects to administrate them.<br>Requires 'System Administrator' permission",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -3750,7 +4113,7 @@
                     "params": [
                         {
                             "key": "analyzedBefore",
-                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).\u003cbr\u003e Either a date (server timezone) or datetime can be provided.",
+                            "description": "Filter the projects for which last analysis is older than the given date (exclusive).<br> Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -3801,7 +4164,7 @@
                         },
                         {
                             "key": "q",
-                            "description": "Limit search to: \u003cul\u003e\u003cli\u003ecomponent names that contain the supplied string\u003c/li\u003e\u003cli\u003ecomponent keys that contain the supplied string\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Limit search to: <ul><li>component names that contain the supplied string</li><li>component keys that contain the supplied string</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sonar"
@@ -3821,7 +4184,7 @@
                 },
                 {
                     "key": "update_key",
-                    "description": "Update a project or module key and all its sub-components keys.\u003cbr\u003eRequires the permission \u0027Administer\u0027 on the specified project.",
+                    "description": "Update a project or module key and all its sub-components keys.<br>Requires the permission 'Administer' on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3850,7 +4213,7 @@
                 },
                 {
                     "key": "update_visibility",
-                    "description": "Updates visibility of a project.\u003cbr\u003eRequires \u0027Project administer\u0027 permission on the specified project",
+                    "description": "Updates visibility of a project.<br>Requires 'Project administer' permission on the specified project",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3923,7 +4286,7 @@
             "actions": [
                 {
                     "key": "copy",
-                    "description": "Copy a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Copy a Quality Gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -3954,7 +4317,7 @@
                 },
                 {
                     "key": "create",
-                    "description": "Create a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Create a Quality Gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -3979,21 +4342,21 @@
                 },
                 {
                     "key": "create_condition",
-                    "description": "Add a new condition to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Add a new condition to a quality gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters",
+                            "description": "Removed optional 'warning' and 'period' parameters",
                             "version": "7.6"
                         },
                         {
-                            "description": "Made \u0027error\u0027 parameter mandatory",
+                            "description": "Made 'error' parameter mandatory",
                             "version": "7.6"
                         },
                         {
-                            "description": "Reduced the possible values of \u0027op\u0027 parameter to LT and GT",
+                            "description": "Reduced the possible values of 'op' parameter to LT and GT",
                             "version": "7.6"
                         }
                     ],
@@ -4015,14 +4378,14 @@
                         },
                         {
                             "key": "metric",
-                            "description": "Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Condition metric.<br/> Only metric of the following types are allowed:<ul><li>INT</li><li>MILLISEC</li><li>RATING</li><li>WORK_DUR</li><li>FLOAT</li><li>PERCENT</li><li>LEVEL</li></ul>Following metrics are forbidden:<ul><li>alert_status</li><li>security_hotspots</li><li>new_security_hotspots</li></ul>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "blocker_violations, vulnerabilities, new_code_smells"
                         },
                         {
                             "key": "op",
-                            "description": "Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Condition operator:<br/><ul><li>LT = is lower than</li><li>GT = is greater than</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "GT",
@@ -4042,7 +4405,7 @@
                 },
                 {
                     "key": "delete_condition",
-                    "description": "Delete a condition from a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Delete a condition from a quality gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4066,13 +4429,13 @@
                 },
                 {
                     "key": "deselect",
-                    "description": "Remove the association of a project from a quality gate.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer Quality Gates\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Remove the association of a project from a quality gate.<br>Requires one of the following permissions:<ul><li>'Administer Quality Gates'</li><li>'Administer' rights on the project</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "The parameter \u0027gateId\u0027 was removed",
+                            "description": "The parameter 'gateId' was removed",
                             "version": "6.6"
                         }
                     ],
@@ -4103,7 +4466,7 @@
                 },
                 {
                     "key": "destroy",
-                    "description": "Delete a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Delete a Quality Gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4127,17 +4490,17 @@
                 },
                 {
                     "key": "get_by_project",
-                    "description": "Get the quality gate of a project.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Get the quality gate of a project.<br />Requires one of the following permissions:<ul><li>'Administer' rights on the specified project</li><li>'Browse' on the specified project</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The parameter \u0027projectId\u0027 has been removed",
+                            "description": "The parameter 'projectId' has been removed",
                             "version": "6.6"
                         },
                         {
-                            "description": "The parameter \u0027projectKey\u0027 has been renamed to \u0027project\u0027",
+                            "description": "The parameter 'projectKey' has been renamed to 'project'",
                             "version": "6.6"
                         },
                         {
@@ -4170,19 +4533,19 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "\u0027isDefault\u0027 field is added on quality gate",
+                            "description": "'isDefault' field is added on quality gate",
                             "version": "7.0"
                         },
                         {
-                            "description": "\u0027default\u0027 field on root level is deprecated",
+                            "description": "'default' field on root level is deprecated",
                             "version": "7.0"
                         },
                         {
-                            "description": "\u0027isBuiltIn\u0027 field is added in the response",
+                            "description": "'isBuiltIn' field is added in the response",
                             "version": "7.0"
                         },
                         {
-                            "description": "\u0027actions\u0027 fields are added in the response",
+                            "description": "'actions' fields are added in the response",
                             "version": "7.0"
                         }
                     ],
@@ -4198,21 +4561,21 @@
                 },
                 {
                     "key": "project_status",
-                    "description": "Get the quality gate status of a project or a Compute Engine task.\u003cbr /\u003eEither \u0027analysisId\u0027, \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided\u003cbr /\u003eThe different statuses returned are: OK, WARN, ERROR, NONE. The NONE status is returned when there is no quality gate associated with the analysis.\u003cbr /\u003eReturns an HTTP code 404 if the analysis associated with the task is not found or does not exist.\u003cbr /\u003eRequires one of the following permissions:\u003cul\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified project\u003c/li\u003e\u003cli\u003e\u0027Browse\u0027 on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Get the quality gate status of a project or a Compute Engine task.<br />Either 'analysisId', 'projectId' or 'projectKey' must be provided<br />The different statuses returned are: OK, WARN, ERROR, NONE. The NONE status is returned when there is no quality gate associated with the analysis.<br />Returns an HTTP code 404 if the analysis associated with the task is not found or does not exist.<br />Requires one of the following permissions:<ul><li>'Administer' rights on the specified project</li><li>'Browse' on the specified project</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The parameters \u0027branch\u0027 and \u0027pullRequest\u0027 were added",
+                            "description": "The parameters 'branch' and 'pullRequest' were added",
                             "version": "7.7"
                         },
                         {
-                            "description": "The field \u0027warning\u0027 is deprecated from the response",
+                            "description": "The field 'warning' is deprecated from the response",
                             "version": "7.6"
                         },
                         {
-                            "description": "The field \u0027ignoredConditions\u0027 is added to the response",
+                            "description": "The field 'ignoredConditions' is added to the response",
                             "version": "6.4"
                         }
                     ],
@@ -4233,7 +4596,7 @@
                         },
                         {
                             "key": "projectId",
-                            "description": "Project id. Doesn\u0027t work with branches or pull requests",
+                            "description": "Project id. Doesn't work with branches or pull requests",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
@@ -4256,7 +4619,7 @@
                 },
                 {
                     "key": "rename",
-                    "description": "Rename a Quality Gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Rename a Quality Gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4288,21 +4651,21 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search for projects associated (or not) to a quality gate.\u003cbr/\u003eOnly authorized projects for current user will be returned.",
+                    "description": "Search for projects associated (or not) to a quality gate.<br/>Only authorized projects for current user will be returned.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "New field \u0027paging\u0027 in response",
+                            "description": "New field 'paging' in response",
                             "version": "7.9"
                         },
                         {
-                            "description": "New field \u0027key\u0027 returning the project key in \u0027results\u0027 response",
+                            "description": "New field 'key' returning the project key in 'results' response",
                             "version": "7.9"
                         },
                         {
-                            "description": "Field \u0027more\u0027 is deprecated in the response",
+                            "description": "Field 'more' is deprecated in the response",
                             "version": "7.9"
                         }
                     ],
@@ -4345,7 +4708,7 @@
                         },
                         {
                             "key": "selected",
-                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "description": "Depending on the value, show only selected items (selected=selected), deselected items (selected=deselected), or all items with their selection status (selected=all).",
                             "required": false,
                             "internal": false,
                             "defaultValue": "selected",
@@ -4359,7 +4722,7 @@
                 },
                 {
                     "key": "select",
-                    "description": "Associate a project to a quality gate.\u003cbr\u003eThe \u0027projectId\u0027 or \u0027projectKey\u0027 must be provided.\u003cbr\u003eProject id as a numeric value is deprecated since 6.1. Please use the id similar to \u0027AU-TpxcA-iU5OvuD2FLz\u0027.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Associate a project to a quality gate.<br>The 'projectId' or 'projectKey' must be provided.<br>Project id as a numeric value is deprecated since 6.1. Please use the id similar to 'AU-TpxcA-iU5OvuD2FLz'.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4397,7 +4760,7 @@
                 },
                 {
                     "key": "set_as_default",
-                    "description": "Set a quality gate as the default quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Set a quality gate as the default quality gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4427,15 +4790,19 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "\u0027period\u0027 and \u0027warning\u0027 fields of conditions are removed from the response",
+                            "description": "'isCleanAsYouCode' field is added to the response",
+                            "version": "18 DEC, 2023"
+                        },
+                        {
+                            "description": "'period' and 'warning' fields of conditions are removed from the response",
                             "version": "7.6"
                         },
                         {
-                            "description": "\u0027isBuiltIn\u0027 field is added to the response",
+                            "description": "'isBuiltIn' field is added to the response",
                             "version": "7.0"
                         },
                         {
-                            "description": "\u0027actions\u0027 field is added in the response",
+                            "description": "'actions' field is added in the response",
                             "version": "7.0"
                         }
                     ],
@@ -4479,21 +4846,21 @@
                 },
                 {
                     "key": "update_condition",
-                    "description": "Update a condition attached to a quality gate.\u003cbr\u003eRequires the \u0027Administer Quality Gates\u0027 permission.",
+                    "description": "Update a condition attached to a quality gate.<br>Requires the 'Administer Quality Gates' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "Removed optional \u0027warning\u0027 and \u0027period\u0027 parameters",
+                            "description": "Removed optional 'warning' and 'period' parameters",
                             "version": "7.6"
                         },
                         {
-                            "description": "Made \u0027error\u0027 parameter mandatory",
+                            "description": "Made 'error' parameter mandatory",
                             "version": "7.6"
                         },
                         {
-                            "description": "Reduced the possible values of \u0027op\u0027 parameter to LT and GT",
+                            "description": "Reduced the possible values of 'op' parameter to LT and GT",
                             "version": "7.6"
                         }
                     ],
@@ -4515,14 +4882,14 @@
                         },
                         {
                             "key": "metric",
-                            "description": "Condition metric.\u003cbr/\u003e Only metric of the following types are allowed:\u003cul\u003e\u003cli\u003eINT\u003c/li\u003e\u003cli\u003eMILLISEC\u003c/li\u003e\u003cli\u003eRATING\u003c/li\u003e\u003cli\u003eWORK_DUR\u003c/li\u003e\u003cli\u003eFLOAT\u003c/li\u003e\u003cli\u003ePERCENT\u003c/li\u003e\u003cli\u003eLEVEL\u003c/li\u003e\u003c/ul\u003eFollowing metrics are forbidden:\u003cul\u003e\u003cli\u003ealert_status\u003c/li\u003e\u003cli\u003esecurity_hotspots\u003c/li\u003e\u003cli\u003enew_security_hotspots\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Condition metric.<br/> Only metric of the following types are allowed:<ul><li>INT</li><li>MILLISEC</li><li>RATING</li><li>WORK_DUR</li><li>FLOAT</li><li>PERCENT</li><li>LEVEL</li></ul>Following metrics are forbidden:<ul><li>alert_status</li><li>security_hotspots</li><li>new_security_hotspots</li></ul>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "blocker_violations, vulnerabilities, new_code_smells"
                         },
                         {
                             "key": "op",
-                            "description": "Condition operator:\u003cbr/\u003e\u003cul\u003e\u003cli\u003eLT \u003d is lower than\u003c/li\u003e\u003cli\u003eGT \u003d is greater than\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Condition operator:<br/><ul><li>LT = is lower than</li><li>GT = is greater than</li></ul>",
                             "required": false,
                             "internal": false,
                             "exampleValue": "GT",
@@ -4548,7 +4915,7 @@
             "actions": [
                 {
                     "key": "activate_rule",
-                    "description": "Activate a rule on a Quality Profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Activate a rule on a Quality Profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4556,7 +4923,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "description": "Quality Profile key. Can be obtained through <code>api/qualityprofiles/search</code>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -4565,10 +4932,10 @@
                         },
                         {
                             "key": "params",
-                            "description": "Parameters as semi-colon list of \u003ccode\u003ekey\u003dvalue\u003c/code\u003e. Ignored if parameter reset is true.",
+                            "description": "Parameters as semi-colon list of <code>key=value</code>. Ignored if parameter reset is true.",
                             "required": false,
                             "internal": false,
-                            "exampleValue": "params\u003dkey1\u003dv1;key2\u003dv2"
+                            "exampleValue": "params=key1=v1;key2=v2"
                         },
                         {
                             "key": "reset",
@@ -4608,7 +4975,7 @@
                 },
                 {
                     "key": "activate_rules",
-                    "description": "Bulk-activate rules on one quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Bulk-activate rules on one quality profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4616,7 +4983,7 @@
                     "params": [
                         {
                             "key": "activation",
-                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter 'qprofile' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -4661,15 +5028,52 @@
                             "exampleValue": "2014-06-22"
                         },
                         {
+                            "key": "cleanCodeAttributeCategories",
+                            "description": "Comma-separated list of Clean Code Attribute Categories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ADAPTABLE,INTENTIONAL",
+                            "possibleValues": [
+                                "ADAPTABLE",
+                                "CONSISTENT",
+                                "INTENTIONAL",
+                                "RESPONSIBLE"
+                            ]
+                        },
+                        {
                             "key": "cwe",
-                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "description": "Comma-separated list of CWE identifiers. Use 'unknown' to select rules not associated to any CWE.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "12,125,unknown"
                         },
                         {
+                            "key": "impactSeverities",
+                            "description": "Comma-separated list of Software Quality Severities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "HIGH,MEDIUM",
+                            "possibleValues": [
+                                "LOW",
+                                "MEDIUM",
+                                "HIGH"
+                            ]
+                        },
+                        {
+                            "key": "impactSoftwareQualities",
+                            "description": "Comma-separated list of Software Qualities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "MAINTAINABILITY,RELIABILITY",
+                            "possibleValues": [
+                                "MAINTAINABILITY",
+                                "RELIABILITY",
+                                "SECURITY"
+                            ]
+                        },
+                        {
                             "key": "inheritance",
-                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "INHERITED,OVERRIDES",
@@ -4733,7 +5137,7 @@
                         },
                         {
                             "key": "qprofile",
-                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Quality profile key to filter on. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
@@ -4771,9 +5175,9 @@
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "porous-defenses",
                                 "insecure-interaction",
-                                "risky-resource",
-                                "porous-defenses"
+                                "risky-resource"
                             ]
                         },
                         {
@@ -4792,11 +5196,13 @@
                         },
                         {
                             "key": "sonarsourceSecurity",
-                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "description": "Comma-separated list of SonarSource security categories. Use 'others' to select rules not associated with any category",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sql-injection,command-injection,others",
                             "possibleValues": [
+                                "buffer-overflow",
+                                "permission",
                                 "sql-injection",
                                 "command-injection",
                                 "path-traversal-injection",
@@ -4843,7 +5249,7 @@
                         },
                         {
                             "key": "targetKey",
-                            "description": "Quality Profile key on which the rule activation is done. To retrieve a quality profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "description": "Quality Profile key on which the rule activation is done. To retrieve a quality profile key please see <code>api/qualityprofiles/search</code>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "AU-TpxcA-iU5OvuD2FL0",
@@ -4889,7 +5295,7 @@
                 },
                 {
                     "key": "add_project",
-                    "description": "Associate a project with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Associate a project with a quality profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li>  <li>Administer right on the specified project</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -4897,7 +5303,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -4907,15 +5313,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -4923,20 +5331,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -4960,7 +5374,7 @@
                         },
                         {
                             "key": "projectUuid",
-                            "description": "Project ID. Either this parameter or \u0027project\u0027 must be set.",
+                            "description": "Project ID. Either this parameter or 'project' must be set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-TpxcA-iU5OvuD2FL5",
@@ -4968,7 +5382,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -4983,11 +5397,16 @@
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
-                    "changelog": [],
+                    "changelog": [
+                        {
+                            "description": "The 'priority' field is now deprecated.",
+                            "version": "26 Sep, 2023"
+                        }
+                    ],
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -4997,15 +5416,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5013,20 +5434,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -5041,7 +5468,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -5052,7 +5479,7 @@
                 },
                 {
                     "key": "change_parent",
-                    "description": "Change a quality profile\u0027s parent.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Change a quality profile's parent.<br>Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -5060,7 +5487,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5070,15 +5497,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5086,20 +5515,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -5114,7 +5549,7 @@
                         },
                         {
                             "key": "parentKey",
-                            "description": "New parent profile key.\u003cbr\u003e If no profile is provided, the inheritance link with current parent profile (if any) is broken, which deactivates all rules which come from the parent and are not overridden.",
+                            "description": "New parent profile key.<br> If no profile is provided, the inheritance link with current parent profile (if any) is broken, which deactivates all rules which come from the parent and are not overridden.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-TpxcA-iU5OvuD2FLz",
@@ -5122,14 +5557,14 @@
                         },
                         {
                             "key": "parentQualityProfile",
-                            "description": "Quality profile name. If this parameter is set, \u0027parentKey\u0027 must not be set and \u0027language\u0027 must be set to disambiguate.",
+                            "description": "Quality profile name. If this parameter is set, 'parentKey' must not be set and 'language' must be set to disambiguate.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way"
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -5144,11 +5579,20 @@
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
-                    "changelog": [],
+                    "changelog": [
+                        {
+                            "description": "Added 'cleanCodeAttribute', 'cleanCodeAttributeCategory', and 'impacts' fields",
+                            "version": "25 Sep, 2023"
+                        },
+                        {
+                            "description": "Added fields 'oldCleanCodeAttribute', 'newCleanCodeAttribute', 'oldCleanCodeAttributeCategory', 'newCleanCodeAttributeCategory' and 'impactChanges' to 'params' section of response",
+                            "version": "15 Dec, 2023"
+                        }
+                    ],
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5158,15 +5602,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5174,20 +5620,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -5219,7 +5671,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -5228,14 +5680,14 @@
                         },
                         {
                             "key": "since",
-                            "description": "Start date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "description": "Start date for the changelog. <br>Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
                         },
                         {
                             "key": "to",
-                            "description": "End date for the changelog. \u003cbr\u003eEither a date (server timezone) or datetime can be provided.",
+                            "description": "End date for the changelog. <br>Either a date (server timezone) or datetime can be provided.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "2017-10-19 or 2017-10-19T13:00:00+0200"
@@ -5244,7 +5696,7 @@
                 },
                 {
                     "key": "copy",
-                    "description": "Copy a quality profile.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "description": "Copy a quality profile.<br> Requires to be logged in and the 'Administer Quality Profiles' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -5268,7 +5720,7 @@
                 },
                 {
                     "key": "create",
-                    "description": "Create a quality profile.\u003cbr\u003eRequires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "description": "Create a quality profile.<br>Requires to be logged in and the 'Administer Quality Profiles' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -5283,12 +5735,14 @@
                             "possibleValues": [
                                 "abap",
                                 "apex",
+                                "azureresourcemanager",
                                 "c",
                                 "cloudformation",
                                 "cobol",
                                 "cpp",
                                 "cs",
                                 "css",
+                                "docker",
                                 "flex",
                                 "go",
                                 "java",
@@ -5296,16 +5750,22 @@
                                 "json",
                                 "jsp",
                                 "kotlin",
+                                "kubernetes",
                                 "objc",
                                 "php",
+                                "pli",
                                 "plsql",
                                 "py",
+                                "rpg",
                                 "ruby",
                                 "scala",
+                                "secrets",
                                 "swift",
                                 "terraform",
+                                "text",
                                 "ts",
                                 "tsql",
+                                "vb",
                                 "vbnet",
                                 "web",
                                 "xml",
@@ -5333,7 +5793,7 @@
                 },
                 {
                     "key": "deactivate_rule",
-                    "description": "Deactivate a rule on a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Deactivate a rule on a quality profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -5341,7 +5801,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality Profile key. Can be obtained through \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "description": "Quality Profile key. Can be obtained through <code>api/qualityprofiles/search</code>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5361,7 +5821,7 @@
                 },
                 {
                     "key": "deactivate_rules",
-                    "description": "Bulk deactivate rules on Quality profiles.\u003cbr\u003eRequires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Bulk deactivate rules on Quality profiles.<br>Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -5369,7 +5829,7 @@
                     "params": [
                         {
                             "key": "activation",
-                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter 'qprofile' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -5414,15 +5874,52 @@
                             "exampleValue": "2014-06-22"
                         },
                         {
+                            "key": "cleanCodeAttributeCategories",
+                            "description": "Comma-separated list of Clean Code Attribute Categories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ADAPTABLE,INTENTIONAL",
+                            "possibleValues": [
+                                "ADAPTABLE",
+                                "CONSISTENT",
+                                "INTENTIONAL",
+                                "RESPONSIBLE"
+                            ]
+                        },
+                        {
                             "key": "cwe",
-                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "description": "Comma-separated list of CWE identifiers. Use 'unknown' to select rules not associated to any CWE.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "12,125,unknown"
                         },
                         {
+                            "key": "impactSeverities",
+                            "description": "Comma-separated list of Software Quality Severities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "HIGH,MEDIUM",
+                            "possibleValues": [
+                                "LOW",
+                                "MEDIUM",
+                                "HIGH"
+                            ]
+                        },
+                        {
+                            "key": "impactSoftwareQualities",
+                            "description": "Comma-separated list of Software Qualities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "MAINTAINABILITY,RELIABILITY",
+                            "possibleValues": [
+                                "MAINTAINABILITY",
+                                "RELIABILITY",
+                                "SECURITY"
+                            ]
+                        },
+                        {
                             "key": "inheritance",
-                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "INHERITED,OVERRIDES",
@@ -5486,7 +5983,7 @@
                         },
                         {
                             "key": "qprofile",
-                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Quality profile key to filter on. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
@@ -5524,9 +6021,9 @@
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "porous-defenses",
                                 "insecure-interaction",
-                                "risky-resource",
-                                "porous-defenses"
+                                "risky-resource"
                             ]
                         },
                         {
@@ -5545,11 +6042,13 @@
                         },
                         {
                             "key": "sonarsourceSecurity",
-                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "description": "Comma-separated list of SonarSource security categories. Use 'others' to select rules not associated with any category",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sql-injection,command-injection,others",
                             "possibleValues": [
+                                "buffer-overflow",
+                                "permission",
                                 "sql-injection",
                                 "command-injection",
                                 "path-traversal-injection",
@@ -5596,7 +6095,7 @@
                         },
                         {
                             "key": "targetKey",
-                            "description": "Quality Profile key on which the rule deactivation is done. To retrieve a profile key please see \u003ccode\u003eapi/qualityprofiles/search\u003c/code\u003e",
+                            "description": "Quality Profile key on which the rule deactivation is done. To retrieve a profile key please see <code>api/qualityprofiles/search</code>",
                             "required": true,
                             "internal": false,
                             "exampleValue": "AU-TpxcA-iU5OvuD2FL1",
@@ -5627,7 +6126,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete a quality profile and all its descendants. The default quality profile cannot be deleted.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Delete a quality profile and all its descendants. The default quality profile cannot be deleted.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -5635,7 +6134,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5645,15 +6144,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5661,20 +6162,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -5689,7 +6196,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -5737,12 +6244,14 @@
                             "possibleValues": [
                                 "abap",
                                 "apex",
+                                "azureresourcemanager",
                                 "c",
                                 "cloudformation",
                                 "cobol",
                                 "cpp",
                                 "cs",
                                 "css",
+                                "docker",
                                 "flex",
                                 "go",
                                 "java",
@@ -5750,16 +6259,22 @@
                                 "json",
                                 "jsp",
                                 "kotlin",
+                                "kubernetes",
                                 "objc",
                                 "php",
+                                "pli",
                                 "plsql",
                                 "py",
+                                "rpg",
                                 "ruby",
                                 "scala",
+                                "secrets",
                                 "swift",
                                 "terraform",
+                                "text",
                                 "ts",
                                 "tsql",
+                                "vb",
                                 "vbnet",
                                 "web",
                                 "xml",
@@ -5802,7 +6317,7 @@
                 },
                 {
                     "key": "inheritance",
-                    "description": "Show a quality profile\u0027s ancestors and children.",
+                    "description": "Show a quality profile's ancestors and children.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -5810,7 +6325,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5820,15 +6335,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5836,20 +6353,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -5864,7 +6387,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -5881,19 +6404,19 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "\u0027more\u0027 response field is deprecated",
+                            "description": "'more' response field is deprecated",
                             "version": "7.2"
                         },
                         {
-                            "description": "\u0027id\u0027 response field is deprecated",
+                            "description": "'id' response field is deprecated",
                             "version": "6.5"
                         },
                         {
-                            "description": "\u0027uuid\u0027 response field is deprecated and replaced by \u0027id\u0027",
+                            "description": "'uuid' response field is deprecated and replaced by 'id'",
                             "version": "6.0"
                         },
                         {
-                            "description": "\u0027key\u0027 response field has been added to return the project key",
+                            "description": "'key' response field has been added to return the project key",
                             "version": "6.0"
                         }
                     ],
@@ -5935,7 +6458,7 @@
                         },
                         {
                             "key": "selected",
-                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "description": "Depending on the value, show only selected items (selected=selected), deselected items (selected=deselected), or all items with their selection status (selected=all).",
                             "required": false,
                             "internal": false,
                             "defaultValue": "selected",
@@ -5949,7 +6472,7 @@
                 },
                 {
                     "key": "remove_project",
-                    "description": "Remove a project\u0027s association with a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e  \u003cli\u003eAdminister right on the specified project\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Remove a project's association with a quality profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li>  <li>Administer right on the specified project</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -5957,7 +6480,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -5967,15 +6490,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -5983,20 +6508,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -6020,7 +6551,7 @@
                         },
                         {
                             "key": "projectUuid",
-                            "description": "Project ID. Either this parameter, or \u0027project\u0027 must be set.",
+                            "description": "Project ID. Either this parameter, or 'project' must be set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-TpxcB-iU5OvuD2FL6",
@@ -6028,7 +6559,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -6039,7 +6570,7 @@
                 },
                 {
                     "key": "rename",
-                    "description": "Rename a quality profile.\u003cbr\u003e Requires one of the following permissions:\u003cul\u003e  \u003cli\u003e\u0027Administer Quality Profiles\u0027\u003c/li\u003e  \u003cli\u003eEdit right on the specified quality profile\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Rename a quality profile.<br> Requires one of the following permissions:<ul>  <li>'Administer Quality Profiles'</li>  <li>Edit right on the specified quality profile</li></ul>",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -6064,7 +6595,7 @@
                 },
                 {
                     "key": "restore",
-                    "description": "Restore a quality profile using an XML file. The restored profile name is taken from the backup file, so if a profile with the same name and language already exists, it will be overwritten.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "description": "Restore a quality profile using an XML file. The restored profile name is taken from the backup file, so if a profile with the same name and language already exists, it will be overwritten.<br> Requires to be logged in and the 'Administer Quality Profiles' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -6087,7 +6618,7 @@
                 },
                 {
                     "key": "restore_built_in",
-                    "description": "This web service has no effect since 6.4. It\u0027s no more possible to restore built-in quality profiles because they are automatically updated and read only. Returns HTTP code 410.",
+                    "description": "This web service has no effect since 6.4. It's no more possible to restore built-in quality profiles because they are automatically updated and read only. Returns HTTP code 410.",
                     "deprecatedSince": "6.4",
                     "internal": false,
                     "post": true,
@@ -6102,15 +6633,15 @@
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "Add available actions \u0027delete\u0027 and \u0027associateProjects\u0027",
+                            "description": "Add available actions 'delete' and 'associateProjects'",
                             "version": "7.0"
                         },
                         {
-                            "description": "Add available actions \u0027edit\u0027, \u0027copy\u0027 and \u0027setAsDefault\u0027 and global action \u0027create\u0027",
+                            "description": "Add available actions 'edit', 'copy' and 'setAsDefault' and global action 'create'",
                             "version": "6.6"
                         },
                         {
-                            "description": "The parameters \u0027defaults\u0027, \u0027project\u0027 and \u0027language\u0027 can be combined without any constraint",
+                            "description": "The parameters 'defaults', 'project' and 'language' can be combined without any constraint",
                             "version": "6.5"
                         }
                     ],
@@ -6136,12 +6667,14 @@
                             "possibleValues": [
                                 "abap",
                                 "apex",
+                                "azureresourcemanager",
                                 "c",
                                 "cloudformation",
                                 "cobol",
                                 "cpp",
                                 "cs",
                                 "css",
+                                "docker",
                                 "flex",
                                 "go",
                                 "java",
@@ -6149,16 +6682,22 @@
                                 "json",
                                 "jsp",
                                 "kotlin",
+                                "kubernetes",
                                 "objc",
                                 "php",
+                                "pli",
                                 "plsql",
                                 "py",
+                                "rpg",
                                 "ruby",
                                 "scala",
+                                "secrets",
                                 "swift",
                                 "terraform",
+                                "text",
                                 "ts",
                                 "tsql",
+                                "vb",
                                 "vbnet",
                                 "web",
                                 "xml",
@@ -6194,7 +6733,7 @@
                 },
                 {
                     "key": "set_default",
-                    "description": "Select the default profile for a given language.\u003cbr\u003e Requires to be logged in and the \u0027Administer Quality Profiles\u0027 permission.",
+                    "description": "Select the default profile for a given language.<br> Requires to be logged in and the 'Administer Quality Profiles' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -6202,7 +6741,7 @@
                     "params": [
                         {
                             "key": "key",
-                            "description": "Quality profile key. Mandatory unless \u0027qualityProfile\u0027 and \u0027language\u0027 are specified.",
+                            "description": "Quality profile key. Mandatory unless 'qualityProfile' and 'language' are specified.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy",
@@ -6212,15 +6751,17 @@
                         },
                         {
                             "key": "language",
-                            "description": "Quality profile language. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile language. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "kubernetes",
                                 "css",
                                 "scala",
                                 "jsp",
                                 "py",
                                 "js",
+                                "docker",
                                 "plsql",
                                 "apex",
                                 "java",
@@ -6228,20 +6769,26 @@
                                 "xml",
                                 "flex",
                                 "json",
+                                "text",
                                 "vbnet",
                                 "cloudformation",
-                                "swift",
                                 "yaml",
+                                "swift",
                                 "cpp",
                                 "c",
-                                "go",
                                 "kotlin",
+                                "go",
+                                "rpg",
+                                "pli",
                                 "tsql",
+                                "vb",
+                                "secrets",
                                 "ruby",
                                 "cs",
                                 "cobol",
                                 "php",
                                 "terraform",
+                                "azureresourcemanager",
                                 "abap",
                                 "objc",
                                 "ts"
@@ -6256,7 +6803,7 @@
                         },
                         {
                             "key": "qualityProfile",
-                            "description": "Quality profile name. Mandatory if \u0027key\u0027 is not set.",
+                            "description": "Quality profile name. Mandatory if 'key' is not set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "Sonar way",
@@ -6297,20 +6844,52 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search for a collection of relevant rules matching a specified query.\u003cbr/\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "Search for a collection of relevant rules matching a specified query.<br/>Since 5.5, following fields in the response have been deprecated :<ul><li>\"effortToFixDescription\" becomes \"gapDescription\"</li><li>\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"</li><li>\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"</li><li>\"debtRemFnOffset\" becomes \"remFnBaseEffort\"</li><li>\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"</li><li>\"debtOverloaded\" becomes \"remFnOverloaded\"</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The field \u0027updatedAt\u0027 has been added to the \u0027f\u0027 parameter",
-                            "version": "7.5"
+                            "description": "'cleanCodeAttribute' and 'impacts' added to optional fields",
+                            "version": "08 Sept, 2023"
+                        },
+                        {
+                            "description": "'cleanCodeAttributeCategories', impactSoftwareQualities', and impactSeverities' added to possible values for facets",
+                            "version": "08 Sept, 2023"
+                        },
+                        {
+                            "description": "Response field 'impacts' added",
+                            "version": "08 Sept, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttributeCategory' added",
+                            "version": "08 Sept, 2023"
+                        },
+                        {
+                            "description": "Response field 'cleanCodeAttribute' added",
+                            "version": "08 Sept, 2023"
+                        },
+                        {
+                            "description": "The field 'educationPrinciples' has been added to the payload and the 'f' parameter",
+                            "version": "08 Mar, 2023"
+                        },
+                        {
+                            "description": "The field 'htmlDesc' has been deprecated use 'descriptionSections' instead",
+                            "version": "13 Dec, 2022"
+                        },
+                        {
+                            "description": "The field 'descriptionSections' has been added to the payload",
+                            "version": "13 Dec, 2022"
+                        },
+                        {
+                            "description": "The field 'descriptionSections' has been added to the 'f' parameter",
+                            "version": "13 Dec, 2022"
                         }
                     ],
                     "params": [
                         {
                             "key": "activation",
-                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter \u0027qprofile\u0027 is not set.",
+                            "description": "Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter 'qprofile' is not set.",
                             "required": false,
                             "internal": false,
                             "possibleValues": [
@@ -6355,30 +6934,47 @@
                             "exampleValue": "2014-06-22"
                         },
                         {
+                            "key": "cleanCodeAttributeCategories",
+                            "description": "Comma-separated list of Clean Code Attribute Categories",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "ADAPTABLE,INTENTIONAL",
+                            "possibleValues": [
+                                "ADAPTABLE",
+                                "CONSISTENT",
+                                "INTENTIONAL",
+                                "RESPONSIBLE"
+                            ]
+                        },
+                        {
                             "key": "cwe",
-                            "description": "Comma-separated list of CWE identifiers. Use \u0027unknown\u0027 to select rules not associated to any CWE.",
+                            "description": "Comma-separated list of CWE identifiers. Use 'unknown' to select rules not associated to any CWE.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "12,125,unknown"
                         },
                         {
                             "key": "f",
-                            "description": "Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :\u003cul\u003e\u003cli\u003e\"defaultDebtRemFn\" becomes \"defaultRemFn\"\u003c/li\u003e\u003cli\u003e\"debtRemFn\" becomes \"remFn\"\u003c/li\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003e",
+                            "description": "Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :<ul><li>\"defaultDebtRemFn\" becomes \"defaultRemFn\"</li><li>\"debtRemFn\" becomes \"remFn\"</li><li>\"effortToFixDescription\" becomes \"gapDescription\"</li><li>\"debtOverloaded\" becomes \"remFnOverloaded\"</li></ul>",
                             "required": false,
                             "internal": false,
-                            "exampleValue": "repo,name",
+                            "exampleValue": "isExternal,lang",
                             "possibleValues": [
                                 "actives",
+                                "cleanCodeAttribute",
                                 "createdAt",
                                 "debtOverloaded",
                                 "debtRemFn",
                                 "defaultDebtRemFn",
                                 "defaultRemFn",
                                 "deprecatedKeys",
+                                "descriptionSections",
+                                "educationPrinciples",
                                 "effortToFixDescription",
                                 "gapDescription",
                                 "htmlDesc",
                                 "htmlNote",
+                                "impacts",
                                 "internalKey",
                                 "isExternal",
                                 "isTemplate",
@@ -6419,7 +7015,34 @@
                                 "cwe",
                                 "owaspTop10",
                                 "sansTop25",
-                                "sonarsourceSecurity"
+                                "sonarsourceSecurity",
+                                "cleanCodeAttributeCategories",
+                                "impactSeverities",
+                                "impactSoftwareQualities"
+                            ]
+                        },
+                        {
+                            "key": "impactSeverities",
+                            "description": "Comma-separated list of Software Quality Severities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "HIGH,MEDIUM",
+                            "possibleValues": [
+                                "LOW",
+                                "MEDIUM",
+                                "HIGH"
+                            ]
+                        },
+                        {
+                            "key": "impactSoftwareQualities",
+                            "description": "Comma-separated list of Software Qualities",
+                            "required": false,
+                            "internal": false,
+                            "exampleValue": "MAINTAINABILITY,RELIABILITY",
+                            "possibleValues": [
+                                "MAINTAINABILITY",
+                                "RELIABILITY",
+                                "SECURITY"
                             ]
                         },
                         {
@@ -6437,7 +7060,7 @@
                         },
                         {
                             "key": "inheritance",
-                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "INHERITED,OVERRIDES",
@@ -6518,7 +7141,7 @@
                         },
                         {
                             "key": "qprofile",
-                            "description": "Quality profile key to filter on. Used only if the parameter \u0027activation\u0027 is set.",
+                            "description": "Quality profile key to filter on. Used only if the parameter 'activation' is set.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "AU-Tpxb--iU5OvuD2FLy"
@@ -6563,9 +7186,9 @@
                             "required": false,
                             "internal": false,
                             "possibleValues": [
+                                "porous-defenses",
                                 "insecure-interaction",
-                                "risky-resource",
-                                "porous-defenses"
+                                "risky-resource"
                             ]
                         },
                         {
@@ -6584,11 +7207,13 @@
                         },
                         {
                             "key": "sonarsourceSecurity",
-                            "description": "Comma-separated list of SonarSource security categories. Use \u0027others\u0027 to select rules not associated with any category",
+                            "description": "Comma-separated list of SonarSource security categories. Use 'others' to select rules not associated with any category",
                             "required": false,
                             "internal": false,
                             "exampleValue": "sql-injection,command-injection,others",
                             "possibleValues": [
+                                "buffer-overflow",
+                                "permission",
                                 "sql-injection",
                                 "command-injection",
                                 "path-traversal-injection",
@@ -6657,15 +7282,32 @@
                 },
                 {
                     "key": "show",
-                    "description": "Get detailed information about a rule\u003cbr\u003eSince 5.5, following fields in the response have been deprecated :\u003cul\u003e\u003cli\u003e\"effortToFixDescription\" becomes \"gapDescription\"\u003c/li\u003e\u003cli\u003e\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"\u003c/li\u003e\u003cli\u003e\"debtRemFnOffset\" becomes \"remFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"\u003c/li\u003e\u003cli\u003e\"debtOverloaded\" becomes \"remFnOverloaded\"\u003c/li\u003e\u003c/ul\u003eIn 7.1, the field \u0027scope\u0027 has been added.",
+                    "description": "Get detailed information about a rule<br>Since 5.5, following fields in the response have been deprecated :<ul><li>\"effortToFixDescription\" becomes \"gapDescription\"</li><li>\"debtRemFnCoeff\" becomes \"remFnGapMultiplier\"</li><li>\"defaultDebtRemFnCoeff\" becomes \"defaultRemFnGapMultiplier\"</li><li>\"debtRemFnOffset\" becomes \"remFnBaseEffort\"</li><li>\"defaultDebtRemFnOffset\" becomes \"defaultRemFnBaseEffort\"</li><li>\"debtOverloaded\" becomes \"remFnOverloaded\"</li></ul>In 7.1, the field 'scope' has been added.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
-                    "changelog": [],
+                    "changelog": [
+                        {
+                            "description": "The field 'educationPrinciples' has been added to the payload",
+                            "version": "08 Mar, 2023"
+                        },
+                        {
+                            "description": "The field 'htmlDesc' has been deprecated use 'descriptionSections' instead",
+                            "version": "13 Dec, 2022"
+                        },
+                        {
+                            "description": "The field 'descriptionSections' has been added to the payload",
+                            "version": "13 Dec, 2022"
+                        },
+                        {
+                            "description": "The fields 'cleanCodeAttribute', 'cleanCodeAttributeCategory', and 'impacts' have been added to the payload",
+                            "version": "08 Sept, 2023"
+                        }
+                    ],
                     "params": [
                         {
                             "key": "actives",
-                            "description": "Show rule\u0027s activations for all profiles (\"active rules\")",
+                            "description": "Show rule's activations for all profiles (\"active rules\")",
                             "required": false,
                             "internal": false,
                             "defaultValue": "false",
@@ -6727,7 +7369,7 @@
                 },
                 {
                     "key": "update",
-                    "description": "Update an existing rule.\u003cbr\u003eRequires the \u0027Administer Quality Profiles\u0027 permission",
+                    "description": "Update an existing rule.<br>Requires the 'Administer Quality Profiles' permission",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -6779,7 +7421,7 @@
                         },
                         {
                             "key": "params",
-                            "description": "Parameters as semi-colon list of \u003ckey\u003e\u003d\u003cvalue\u003e, for example \u0027params\u003dkey1\u003dv1;key2\u003dv2\u0027 (Only when updating a custom rule)",
+                            "description": "Parameters as semi-colon list of <key>=<value>, for example 'params=key1=v1;key2=v2' (Only when updating a custom rule)",
                             "required": false,
                             "internal": false
                         },
@@ -6850,13 +7492,13 @@
             "actions": [
                 {
                     "key": "list_definitions",
-                    "description": "List settings definitions.\u003cbr\u003eRequires \u0027Browse\u0027 permission when a component is specified\u003cbr/\u003eTo access licensed settings, authentication is required\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "List settings definitions.<br>Requires 'Browse' permission when a component is specified<br/>To access licensed settings, authentication is required<br/>To access secured settings, one of the following permissions is required: <ul><li>'Execute Analysis'</li><li>'Administer' rights on the specified component</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         }
                     ],
@@ -6872,17 +7514,17 @@
                 },
                 {
                     "key": "reset",
-                    "description": "Remove a setting value.\u003cbr\u003eThe settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.",
+                    "description": "Remove a setting value.<br>The settings defined in conf/sonar.properties are read-only and can't be changed.<br/>Requires the permission 'Administer' on the specified component.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         },
                         {
-                            "description": "The settings defined in conf/sonar.properties are read-only and can\u0027t be changed",
+                            "description": "The settings defined in conf/sonar.properties are read-only and can't be changed",
                             "version": "7.1"
                         }
                     ],
@@ -6921,17 +7563,17 @@
                 },
                 {
                     "key": "set",
-                    "description": "Update a setting value.\u003cbr\u003eEither \u0027value\u0027 or \u0027values\u0027 must be provided.\u003cbr\u003e The settings defined in conf/sonar.properties are read-only and can\u0027t be changed.\u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the specified component.",
+                    "description": "Update a setting value.<br>Either 'value' or 'values' must be provided.<br> The settings defined in conf/sonar.properties are read-only and can't be changed.<br/>Requires the permission 'Administer' on the specified component.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         },
                         {
-                            "description": "The settings defined in conf/sonar.properties are read-only and can\u0027t be changed",
+                            "description": "The settings defined in conf/sonar.properties are read-only and can't be changed",
                             "version": "7.1"
                         }
                     ],
@@ -6950,7 +7592,7 @@
                             "description": "Setting field values. To set several values, the parameter must be called once for each value.",
                             "required": false,
                             "internal": false,
-                            "exampleValue": "fieldValues\u003d{\"firstField\":\"first value\", \"secondField\":\"second value\", \"thirdField\":\"third value\"}"
+                            "exampleValue": "fieldValues={\"firstField\":\"first value\", \"secondField\":\"second value\", \"thirdField\":\"third value\"}"
                         },
                         {
                             "key": "key",
@@ -6972,19 +7614,19 @@
                             "description": "Setting multi value. To set several values, the parameter must be called once for each value.",
                             "required": false,
                             "internal": false,
-                            "exampleValue": "values\u003dfirstValue\u0026values\u003dsecondValue\u0026values\u003dthirdValue"
+                            "exampleValue": "values=firstValue&values=secondValue&values=thirdValue"
                         }
                     ]
                 },
                 {
                     "key": "values",
-                    "description": "List settings values.\u003cbr\u003eIf no value has been set for a setting, then the default value is returned.\u003cbr\u003eThe settings from conf/sonar.properties are excluded from results.\u003cbr\u003eRequires \u0027Browse\u0027 or \u0027Execute Analysis\u0027 permission when a component is specified.\u003cbr/\u003eTo access secured settings, one of the following permissions is required: \u003cul\u003e\u003cli\u003e\u0027Execute Analysis\u0027\u003c/li\u003e\u003cli\u003e\u0027Administer\u0027 rights on the specified component\u003c/li\u003e\u003c/ul\u003e",
+                    "description": "List settings values.<br>If no value has been set for a setting, then the default value is returned.<br>The settings from conf/sonar.properties are excluded from results.<br>Requires 'Browse' or 'Execute Analysis' permission when a component is specified.<br/>To access secured settings, one of the following permissions is required: <ul><li>'Execute Analysis'</li><li>'Administer' rights on the specified component</li></ul>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "The use of module keys in parameter \u0027component\u0027 is deprecated",
+                            "description": "The use of module keys in parameter 'component' is deprecated",
                             "version": "7.6"
                         },
                         {
@@ -7017,7 +7659,7 @@
             "actions": [
                 {
                     "key": "raw",
-                    "description": "Get source code as raw text. Require \u0027See Source Code\u0027 permission on file",
+                    "description": "Get source code as raw text. Require 'See Source Code' permission on file",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7048,7 +7690,7 @@
                 },
                 {
                     "key": "scm",
-                    "description": "Get SCM information of source files. Require See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eAuthor of the commit\u003c/li\u003e\u003cli\u003eDatetime of the commit (before 5.2 it was only the Date)\u003c/li\u003e\u003cli\u003eRevision of the commit (added in 5.2)\u003c/li\u003e\u003c/ol\u003e",
+                    "description": "Get SCM information of source files. Require See Source Code permission on file's project<br/>Each element of the result array is composed of:<ol><li>Line number</li><li>Author of the commit</li><li>Datetime of the commit (before 5.2 it was only the Date)</li><li>Revision of the commit (added in 5.2)</li></ol>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7093,7 +7735,7 @@
                 },
                 {
                     "key": "show",
-                    "description": "Get source code. Requires See Source Code permission on file\u0027s project\u003cbr/\u003eEach element of the result array is composed of:\u003col\u003e\u003cli\u003eLine number\u003c/li\u003e\u003cli\u003eContent of the line\u003c/li\u003e\u003c/ol\u003e",
+                    "description": "Get source code. Requires See Source Code permission on file's project, or organization membership on public projects.<br/>Each element of the result array is composed of:<ol><li>Line number</li><li>Content of the line</li></ol>",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7131,7 +7773,7 @@
             "actions": [
                 {
                     "key": "index",
-                    "description": "The web service is removed and you\u0027re invited to use api/measures/search_history instead",
+                    "description": "The web service is removed and you're invited to use api/measures/search_history instead",
                     "deprecatedSince": "6.3",
                     "internal": false,
                     "post": false,
@@ -7146,13 +7788,13 @@
             "actions": [
                 {
                     "key": "add_user",
-                    "description": "Add a user to a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Add a user to a group.<br />'id' or 'name' must be provided.<br />Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
                     "changelog": [
                         {
-                            "description": "It\u0027s no longer possible to add a user to the default group",
+                            "description": "It's no longer possible to add a user to the default group",
                             "version": "6.4"
                         }
                     ],
@@ -7189,7 +7831,7 @@
                 },
                 {
                     "key": "create",
-                    "description": "Create a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Create a group.<br>Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -7205,7 +7847,7 @@
                         },
                         {
                             "key": "name",
-                            "description": "Name for the new group. A group name cannot be larger than 255 characters and must be unique. The value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used.",
+                            "description": "Name for the new group. A group name cannot be larger than 255 characters and must be unique. The value 'anyone' (whatever the case) is reserved and cannot be used.",
                             "required": true,
                             "internal": false,
                             "exampleValue": "sonar-users",
@@ -7222,7 +7864,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete a group. The default groups cannot be deleted.\u003cbr/\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr /\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Delete a group. The default groups cannot be deleted.<br/>'id' or 'name' must be provided.<br />Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7253,7 +7895,7 @@
                 },
                 {
                     "key": "remove_user",
-                    "description": "Remove a user from a group.\u003cbr /\u003e\u0027id\u0027 or \u0027name\u0027 must be provided.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Remove a user from a group.<br />'id' or 'name' must be provided.<br>Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7291,7 +7933,7 @@
                 },
                 {
                     "key": "search",
-                    "description": "Search for user groups.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Search for user groups.<br>Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7301,7 +7943,7 @@
                             "version": "6.4"
                         },
                         {
-                            "description": "\u0027default\u0027 response field has been added",
+                            "description": "'default' response field has been added",
                             "version": "6.4"
                         }
                     ],
@@ -7352,7 +7994,7 @@
                 },
                 {
                     "key": "update",
-                    "description": "Update a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Update a group.<br>Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7380,7 +8022,7 @@
                         },
                         {
                             "key": "name",
-                            "description": "New optional name for the group. A group name cannot be larger than 255 characters and must be unique. Value \u0027anyone\u0027 (whatever the case) is reserved and cannot be used. If value is empty or not defined, then name is not changed.",
+                            "description": "New optional name for the group. A group name cannot be larger than 255 characters and must be unique. Value 'anyone' (whatever the case) is reserved and cannot be used. If value is empty or not defined, then name is not changed.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "my-group",
@@ -7390,7 +8032,7 @@
                 },
                 {
                     "key": "users",
-                    "description": "Search for users with membership information with respect to a group.\u003cbr\u003eRequires the following permission: \u0027Administer System\u0027.",
+                    "description": "Search for users with membership information with respect to a group.<br>Requires the following permission: 'Administer System'.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7442,7 +8084,7 @@
                         },
                         {
                             "key": "selected",
-                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "description": "Depending on the value, show only selected items (selected=selected), deselected items (selected=deselected), or all items with their selection status (selected=all).",
                             "required": false,
                             "internal": false,
                             "defaultValue": "selected",
@@ -7473,11 +8115,11 @@
         },
         {
             "path": "api/user_tokens",
-            "description": "List, create, and delete a user\u0027s access tokens.",
+            "description": "List, create, and delete a user's access tokens.",
             "actions": [
                 {
                     "key": "generate",
-                    "description": "Generate a user access token. \u003cbr /\u003ePlease keep your tokens secret. They enable to authenticate and analyze projects.\u003cbr /\u003eIt requires administration permissions to specify a \u0027login\u0027 and generate a token for another user. Otherwise, a token is generated for the current user.",
+                    "description": "Generate a user access token. <br />Please keep your tokens secret. They enable to authenticate and analyze projects.<br />It requires administration permissions to specify a 'login' and generate a token for another user. Otherwise, a token is generated for the current user.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -7502,7 +8144,7 @@
                 },
                 {
                     "key": "revoke",
-                    "description": "Revoke a user access token. \u003cbr/\u003eIt requires administration permissions to specify a \u0027login\u0027 and revoke a token for another user. Otherwise, the token for the current user is revoked.",
+                    "description": "Revoke a user access token. <br/>It requires administration permissions to specify a 'login' and revoke a token for another user. Otherwise, the token for the current user is revoked.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7526,13 +8168,13 @@
                 },
                 {
                     "key": "search",
-                    "description": "List the access tokens of a user.\u003cbr\u003eThe login must exist and active.\u003cbr\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user is using a token many times in less than one hour.\u003cbr/It requires administration permissions to specify a \u0027login\u0027 and list the tokens of another user. Otherwise, tokens for the current user are listed.",
+                    "description": "List the access tokens of a user.<br>The login must exist and active.<br>Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user is using a token many times in less than one hour.<br/It requires administration permissions to specify a 'login' and list the tokens of another user. Otherwise, tokens for the current user are listed.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "New field \u0027lastConnectionDate\u0027 is added to response",
+                            "description": "New field 'lastConnectionDate' is added to response",
                             "version": "7.7"
                         }
                     ],
@@ -7554,7 +8196,7 @@
             "actions": [
                 {
                     "key": "groups",
-                    "description": "Lists the groups a user belongs to. \u003cbr/\u003eRequires the permission \u0027Administer\u0027 on the organization.",
+                    "description": "Lists the groups a user belongs to. <br/>Requires the permission 'Administer' on the organization.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7564,7 +8206,7 @@
                             "version": "6.4"
                         },
                         {
-                            "description": "\u0027default\u0027 response field has been added",
+                            "description": "'default' response field has been added",
                             "version": "6.4"
                         }
                     ],
@@ -7608,7 +8250,7 @@
                         },
                         {
                             "key": "selected",
-                            "description": "Depending on the value, show only selected items (selected\u003dselected), deselected items (selected\u003ddeselected), or all items with their selection status (selected\u003dall).",
+                            "description": "Depending on the value, show only selected items (selected=selected), deselected items (selected=deselected), or all items with their selection status (selected=all).",
                             "required": false,
                             "internal": false,
                             "defaultValue": "selected",
@@ -7622,13 +8264,13 @@
                 },
                 {
                     "key": "search",
-                    "description": "Get a list of active users. \u003cbr/\u003eThe following fields are only returned when user has Administer System permission or for logged-in in user :\u003cul\u003e   \u003cli\u003e\u0027email\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalIdentity\u0027\u003c/li\u003e   \u003cli\u003e\u0027externalProvider\u0027\u003c/li\u003e   \u003cli\u003e\u0027groups\u0027\u003c/li\u003e   \u003cli\u003e\u0027lastConnectionDate\u0027\u003c/li\u003e   \u003cli\u003e\u0027tokensCount\u0027\u003c/li\u003e\u003c/ul\u003eField \u0027lastConnectionDate\u0027 is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.",
+                    "description": "Get a list of active users. <br/>The following fields are only returned for the logged-in user :<ul>   <li>'email'</li>   <li>'externalIdentity'</li>   <li>'externalProvider'</li>   <li>'groups'</li>   <li>'lastConnectionDate'</li>   <li>'tokensCount'</li></ul>Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "New field \u0027lastConnectionDate\u0027 is added to response",
+                            "description": "New field 'lastConnectionDate' is added to response",
                             "version": "7.7"
                         },
                         {
@@ -7649,6 +8291,13 @@
                         }
                     ],
                     "params": [
+                        {
+                            "key": "ids",
+                            "description": "Filter on a list of one or more (max 30) user identifiers (comma-separated UUID V4)",
+                            "required": false,
+                            "internal": false,
+                            "maximumLength": 1110
+                        },
                         {
                             "key": "p",
                             "description": "1-based page number",
@@ -7683,7 +8332,7 @@
             "actions": [
                 {
                     "key": "create",
-                    "description": "Create a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project.",
+                    "description": "Create a Webhook.<br>Requires 'Administer' permission on the specified project.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": true,
@@ -7715,7 +8364,7 @@
                         },
                         {
                             "key": "secret",
-                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header",
+                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the 'X-Sonar-Webhook-HMAC-SHA256' header",
                             "required": false,
                             "internal": false,
                             "exampleValue": "your_secret",
@@ -7724,7 +8373,7 @@
                         },
                         {
                             "key": "url",
-                            "description": "Server endpoint that will receive the webhook payload, for example \u0027http://my_server/foo\u0027. If HTTP Basic authentication is used, HTTPS is recommended to avoid man in the middle attacks. Example: \u0027https://myLogin:myPassword@my_server/foo\u0027",
+                            "description": "Server endpoint that will receive the webhook payload, for example 'http://my_server/foo'. If HTTP Basic authentication is used, HTTPS is recommended to avoid man in the middle attacks. Example: 'https://myLogin:myPassword@my_server/foo'",
                             "required": true,
                             "internal": false,
                             "exampleValue": "https://www.google.com/sonar",
@@ -7734,7 +8383,7 @@
                 },
                 {
                     "key": "delete",
-                    "description": "Delete a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "description": "Delete a Webhook.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7752,7 +8401,7 @@
                 },
                 {
                     "key": "deliveries",
-                    "description": "Get the recent deliveries for a specified project or Compute Engine task.\u003cbr/\u003eRequire \u0027Administer\u0027 permission on the related project.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.",
+                    "description": "Get the recent deliveries for a specified project or Compute Engine task.<br/>Require 'Administer' permission on the related project.<br/>Note that additional information are returned by api/webhooks/delivery.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7800,7 +8449,7 @@
                 },
                 {
                     "key": "delivery",
-                    "description": "Get a webhook delivery by its id.\u003cbr/\u003eNote that additional information are returned by api/webhooks/delivery.",
+                    "description": "Get a webhook delivery by its id.<br/>Note that additional information are returned by api/webhooks/delivery.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
@@ -7817,13 +8466,17 @@
                 },
                 {
                     "key": "list",
-                    "description": "Search for global webhooks or project webhooks. Webhooks are ordered by name.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "description": "Search for global webhooks or project webhooks. Webhooks are ordered by name.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.",
                     "internal": false,
                     "post": false,
                     "hasResponseExample": true,
                     "changelog": [
                         {
-                            "description": "Field \u0027secret\u0027 added to response",
+                            "description": "Field 'secret' replaced by flag 'hasSecret' in response",
+                            "version": "03 Sep, 2023"
+                        },
+                        {
+                            "description": "Field 'secret' added to response",
                             "version": "7.8"
                         }
                     ],
@@ -7846,7 +8499,7 @@
                 },
                 {
                     "key": "update",
-                    "description": "Update a Webhook.\u003cbr\u003eRequires \u0027Administer\u0027 permission on the specified project, or global \u0027Administer\u0027 permission.",
+                    "description": "Update a Webhook.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.",
                     "internal": false,
                     "post": true,
                     "hasResponseExample": false,
@@ -7862,12 +8515,11 @@
                         },
                         {
                             "key": "secret",
-                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the \u0027X-Sonar-Webhook-HMAC-SHA256\u0027 header",
+                            "description": "If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the 'X-Sonar-Webhook-HMAC-SHA256' header. If blank, any secret previously configured will be removed. If not set, the secret will remain unchanged.",
                             "required": false,
                             "internal": false,
                             "exampleValue": "your_secret",
-                            "maximumLength": 200,
-                            "minimumLength": 1
+                            "maximumLength": 200
                         },
                         {
                             "key": "url",

--- a/sonarcloud/authentication/authentication_gen.go
+++ b/sonarcloud/authentication/authentication_gen.go
@@ -5,7 +5,7 @@ package authentication
 // LogoutRequest Logout a user.
 type LogoutRequest struct{}
 
-// ValidateRequest Check credentials.
+// ValidateRequest Check credentials. Returns true for anonymous user.
 type ValidateRequest struct{}
 
 // ValidateResponse is the response for ValidateRequest

--- a/sonarcloud/hotspots/hotspots_gen.go
+++ b/sonarcloud/hotspots/hotspots_gen.go
@@ -1,0 +1,160 @@
+package hotspots
+
+import paging "github.com/ArgonGlow/go-sonarcloud/sonarcloud/paging"
+
+// AUTOMATICALLY GENERATED, DO NOT EDIT BY HAND!
+
+// ChangeStatusRequest Change the status of a Security Hotpot.<br/>Requires the 'Administer Security Hotspot' permission.
+type ChangeStatusRequest struct {
+	Comment    string `form:"comment,omitempty"`    // Comment text.
+	Hotspot    string `form:"hotspot,omitempty"`    // Key of the Security Hotspot
+	Resolution string `form:"resolution,omitempty"` // Resolution of the Security Hotspot when new status is REVIEWED, otherwise must not be set.
+	Status     string `form:"status,omitempty"`     // New status of the Security Hotspot.
+}
+
+// SearchRequest Search for Security Hotpots.
+type SearchRequest struct {
+	FileUuids       string `form:"fileUuids,omitempty"`       // Comma-separated list of file uuids. Returns only hotspots found in those files. If set, 'files' must not be set.
+	Files           string `form:"files,omitempty"`           // Comma-separated list of file paths. Returns only hotspots found in those files. If set, 'fileUuids' must not be set.
+	Hotspots        string `form:"hotspots,omitempty"`        // Comma-separated list of Security Hotspot keys. This parameter is required unless projectKey is provided.
+	OnlyMine        string `form:"onlyMine,omitempty"`        // If 'projectKey' is provided, returns only Security Hotspots assigned to the current user
+	ProjectKey      string `form:"projectKey,omitempty"`      // Key of the project or application. This parameter is required unless hotspots is provided.
+	Resolution      string `form:"resolution,omitempty"`      // If 'projectKey' is provided and if status is 'REVIEWED', only Security Hotspots with the specified resolution are returned.
+	SinceLeakPeriod string `form:"sinceLeakPeriod,omitempty"` // If '%s' is provided, only Security Hotspots created since the leak period are returned.
+	Status          string `form:"status,omitempty"`          // If 'projectKey' is provided, only Security Hotspots with the specified status are returned.
+}
+
+// SearchResponse is the response for SearchRequest
+type SearchResponse struct {
+	Components []struct {
+		Key          string `json:"key,omitempty"`
+		LongName     string `json:"longName,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		Path         string `json:"path,omitempty"`
+		Qualifier    string `json:"qualifier,omitempty"`
+	} `json:"components,omitempty"`
+	Hotspots []struct {
+		Assignee         string  `json:"assignee,omitempty"`
+		Author           string  `json:"author,omitempty"`
+		Component        string  `json:"component,omitempty"`
+		CreationDate     string  `json:"creationDate,omitempty"`
+		Key              string  `json:"key,omitempty"`
+		Line             float64 `json:"line,omitempty"`
+		Message          string  `json:"message,omitempty"`
+		Project          string  `json:"project,omitempty"`
+		RuleKey          string  `json:"ruleKey,omitempty"`
+		SecurityCategory string  `json:"securityCategory,omitempty"`
+		Status           string  `json:"status,omitempty"`
+		TextRange        struct {
+			EndLine     float64 `json:"endLine,omitempty"`
+			EndOffset   float64 `json:"endOffset,omitempty"`
+			StartLine   float64 `json:"startLine,omitempty"`
+			StartOffset float64 `json:"startOffset,omitempty"`
+		} `json:"textRange,omitempty"`
+		UpdateDate               string `json:"updateDate,omitempty"`
+		VulnerabilityProbability string `json:"vulnerabilityProbability,omitempty"`
+	} `json:"hotspots,omitempty"`
+	Paging paging.Paging `json:"paging,omitempty"`
+}
+
+// GetPaging extracts the paging from SearchResponse
+func (r *SearchResponse) GetPaging() *paging.Paging {
+	return &r.Paging
+}
+
+// SearchResponseAll is the collection for SearchRequest
+type SearchResponseAll struct {
+	Components []struct {
+		Key          string `json:"key,omitempty"`
+		LongName     string `json:"longName,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		Path         string `json:"path,omitempty"`
+		Qualifier    string `json:"qualifier,omitempty"`
+	} `json:"components,omitempty"`
+	Hotspots []struct {
+		Assignee         string  `json:"assignee,omitempty"`
+		Author           string  `json:"author,omitempty"`
+		Component        string  `json:"component,omitempty"`
+		CreationDate     string  `json:"creationDate,omitempty"`
+		Key              string  `json:"key,omitempty"`
+		Line             float64 `json:"line,omitempty"`
+		Message          string  `json:"message,omitempty"`
+		Project          string  `json:"project,omitempty"`
+		RuleKey          string  `json:"ruleKey,omitempty"`
+		SecurityCategory string  `json:"securityCategory,omitempty"`
+		Status           string  `json:"status,omitempty"`
+		TextRange        struct {
+			EndLine     float64 `json:"endLine,omitempty"`
+			EndOffset   float64 `json:"endOffset,omitempty"`
+			StartLine   float64 `json:"startLine,omitempty"`
+			StartOffset float64 `json:"startOffset,omitempty"`
+		} `json:"textRange,omitempty"`
+		UpdateDate               string `json:"updateDate,omitempty"`
+		VulnerabilityProbability string `json:"vulnerabilityProbability,omitempty"`
+	} `json:"hotspots,omitempty"`
+}
+
+// ShowRequest Provides the details of a Security Hotspot.
+type ShowRequest struct {
+	Hotspot string `form:"hotspot,omitempty"` // Key of the Security Hotspot
+}
+
+// ShowResponse is the response for ShowRequest
+type ShowResponse struct {
+	Assignee        string `json:"assignee,omitempty"`
+	Author          string `json:"author,omitempty"`
+	CanChangeStatus bool   `json:"canChangeStatus,omitempty"`
+	Changelog       []struct {
+		Avatar       string `json:"avatar,omitempty"`
+		CreationDate string `json:"creationDate,omitempty"`
+		Diffs        []struct {
+			Key      string `json:"key,omitempty"`
+			NewValue string `json:"newValue,omitempty"`
+			OldValue string `json:"oldValue,omitempty"`
+		} `json:"diffs,omitempty"`
+		IsUserActive bool   `json:"isUserActive,omitempty"`
+		User         string `json:"user,omitempty"`
+		UserName     string `json:"userName,omitempty"`
+	} `json:"changelog,omitempty"`
+	Comment []struct {
+		CreatedAt string `json:"createdAt,omitempty"`
+		HtmlText  string `json:"htmlText,omitempty"`
+		Key       string `json:"key,omitempty"`
+		Login     string `json:"login,omitempty"`
+		Markdown  string `json:"markdown,omitempty"`
+	} `json:"comment,omitempty"`
+	Component struct {
+		Key          string `json:"key,omitempty"`
+		LongName     string `json:"longName,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		Path         string `json:"path,omitempty"`
+		Qualifier    string `json:"qualifier,omitempty"`
+	} `json:"component,omitempty"`
+	CreationDate string  `json:"creationDate,omitempty"`
+	Key          string  `json:"key,omitempty"`
+	Line         float64 `json:"line,omitempty"`
+	Message      string  `json:"message,omitempty"`
+	Project      struct {
+		Key          string `json:"key,omitempty"`
+		LongName     string `json:"longName,omitempty"`
+		Name         string `json:"name,omitempty"`
+		Organization string `json:"organization,omitempty"`
+		Qualifier    string `json:"qualifier,omitempty"`
+	} `json:"project,omitempty"`
+	Rule struct {
+		Key                      string `json:"key,omitempty"`
+		Name                     string `json:"name,omitempty"`
+		SecurityCategory         string `json:"securityCategory,omitempty"`
+		VulnerabilityProbability string `json:"vulnerabilityProbability,omitempty"`
+	} `json:"rule,omitempty"`
+	Status     string `json:"status,omitempty"`
+	UpdateDate string `json:"updateDate,omitempty"`
+	Users      []struct {
+		Active bool   `json:"active,omitempty"`
+		Login  string `json:"login,omitempty"`
+		Name   string `json:"name,omitempty"`
+	} `json:"users,omitempty"`
+}

--- a/sonarcloud/hotspots_gen.go
+++ b/sonarcloud/hotspots_gen.go
@@ -1,0 +1,125 @@
+package sonarcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/hotspots"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/paging"
+	"github.com/go-playground/form/v4"
+	"strings"
+)
+
+// AUTOMATICALLY GENERATED, DO NOT EDIT BY HAND!
+
+type Hotspots service
+
+func (s *Hotspots) ChangeStatus(r hotspots.ChangeStatusRequest) error {
+	encoder := form.NewEncoder()
+	values, err := encoder.Encode(r)
+	if err != nil {
+		return fmt.Errorf("could not encode form values: %+v", err)
+	}
+
+	req, err := s.client.PostRequest(fmt.Sprintf("%s/hotspots/change_status", API), strings.NewReader(values.Encode()))
+	if err != nil {
+		return fmt.Errorf("could not create request: %+v", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error trying to execute request: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		if errorResponse, err := ErrorResponseFrom(resp); err != nil {
+			return fmt.Errorf("received non 2xx status code (%d), but could not decode error response: %+v", resp.StatusCode, err)
+		} else {
+			return errorResponse
+		}
+	}
+
+	return nil
+}
+
+func (s *Hotspots) Search(r hotspots.SearchRequest, p paging.Params) (*hotspots.SearchResponse, error) {
+	params := paramsFrom(r, p)
+
+	req, err := s.client.GetRequest(fmt.Sprintf("%s/hotspots/search", API), params...)
+	if err != nil {
+		return nil, fmt.Errorf("could not create request: %+v", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to execute request: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		if errorResponse, err := ErrorResponseFrom(resp); err != nil {
+			return nil, fmt.Errorf("received non 2xx status code (%d), but could not decode error response: %+v", resp.StatusCode, err)
+		} else {
+			return nil, errorResponse
+		}
+	}
+
+	response := &hotspots.SearchResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode response: %+v", err)
+	}
+	return response, nil
+}
+
+func (s *Hotspots) SearchAll(r hotspots.SearchRequest) (*hotspots.SearchResponseAll, error) {
+	p := paging.Params{
+		P:  1,
+		Ps: 100,
+	}
+	response := &hotspots.SearchResponseAll{}
+	for {
+		res, err := s.Search(r, p)
+		if err != nil {
+			return nil, fmt.Errorf("error during call to hotspots.Search: %+v", err)
+		}
+		response.Components = append(response.Components, res.Components...)
+		response.Hotspots = append(response.Hotspots, res.Hotspots...)
+		if res.GetPaging().End() {
+			break
+		} else {
+			p.P++
+		}
+	}
+	return response, nil
+}
+
+func (s *Hotspots) Show(r hotspots.ShowRequest) (*hotspots.ShowResponse, error) {
+	params := paramsFrom(r)
+
+	req, err := s.client.GetRequest(fmt.Sprintf("%s/hotspots/show", API), params...)
+	if err != nil {
+		return nil, fmt.Errorf("could not create request: %+v", err)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error trying to execute request: %+v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		if errorResponse, err := ErrorResponseFrom(resp); err != nil {
+			return nil, fmt.Errorf("received non 2xx status code (%d), but could not decode error response: %+v", resp.StatusCode, err)
+		} else {
+			return nil, errorResponse
+		}
+	}
+
+	response := &hotspots.ShowResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode response: %+v", err)
+	}
+	return response, nil
+}

--- a/sonarcloud/issues/issues_gen.go
+++ b/sonarcloud/issues/issues_gen.go
@@ -172,6 +172,7 @@ type BulkChangeRequest struct {
 	Assign            string `form:"assign,omitempty"`            // To assign the list of issues to a specific user (login), or un-assign all the issues
 	Comment           string `form:"comment,omitempty"`           // To add a comment to a list of issues
 	DoTransition      string `form:"do_transition,omitempty"`     // Transition
+	IsFeedback        string `form:"isFeedback,omitempty"`        // Define if the given comment is a feedback
 	Issues            string `form:"issues,omitempty"`            // Comma-separated list of issue keys
 	RemoveTags        string `form:"remove_tags,omitempty"`       // Remove tags
 	SendNotifications string `form:"sendNotifications,omitempty"` //
@@ -281,8 +282,10 @@ type DeleteCommentResponse struct {
 	} `json:"users,omitempty"`
 }
 
-// DoTransitionRequest Do workflow transition on an issue. Requires authentication and Browse permission on project.<br/>The transitions 'wontfix' and 'falsepositive' require the permission 'Administer Issues'.<br/>The transitions involving security hotspots require the permission 'Administer Security Hotspot'.
+// DoTransitionRequest Do workflow transition on an issue. Requires authentication and Browse permission on project.<br/>The transitions 'accept', 'wontfix', and 'falsepositive' require the permission 'Administer Issues'.<br/>The transitions involving security hotspots require the permission 'Administer Security Hotspot'.
 type DoTransitionRequest struct {
+	Comment    string `form:"comment,omitempty"`    // Comment text
+	IsFeedback string `form:"isFeedback,omitempty"` // Define is the given comment is a feedback
 	Issue      string `form:"issue,omitempty"`      // Issue key
 	Transition string `form:"transition,omitempty"` // Transition
 }
@@ -431,38 +434,40 @@ type EditCommentResponse struct {
 
 // SearchRequest Search for issues.<br>Requires the 'Browse' permission on the specified project(s).
 type SearchRequest struct {
-	AdditionalFields    string `form:"additionalFields,omitempty"`    // Comma-separated list of the optional fields to be returned in response. Action plans are dropped in 5.5, it is not returned in the response.
-	Asc                 string `form:"asc,omitempty"`                 // Ascending sort
-	Assigned            string `form:"assigned,omitempty"`            // To retrieve assigned or unassigned issues
-	Assignees           string `form:"assignees,omitempty"`           // Comma-separated list of assignee logins. The value '__me__' can be used as a placeholder for user who performs the request
-	Author              string `form:"author,omitempty"`              // SCM accounts. To set several values, the parameter must be called once for each value.
-	Authors             string `form:"authors,omitempty"`             // This parameter is deprecated, please use 'author' instead
-	Branch              string `form:"branch,omitempty"`              // Branch key
-	ComponentKeys       string `form:"componentKeys,omitempty"`       // Comma-separated list of component keys. Retrieve issues associated to a specific list of components (and all its descendants). A component can be a project, directory or file.
-	CreatedAfter        string `form:"createdAfter,omitempty"`        // To retrieve issues created after the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided. <br>If this parameter is set, createdSince must not be set
-	CreatedAt           string `form:"createdAt,omitempty"`           // Datetime to retrieve issues created during a specific analysis
-	CreatedBefore       string `form:"createdBefore,omitempty"`       // To retrieve issues created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided.
-	CreatedInLast       string `form:"createdInLast,omitempty"`       // To retrieve issues created during a time span before the current time (exclusive). Accepted units are 'y' for year, 'm' for month, 'w' for week and 'd' for day. If this parameter is set, createdAfter must not be set
-	Cwe                 string `form:"cwe,omitempty"`                 // Comma-separated list of CWE identifiers. Use 'unknown' to select issues not associated to any CWE.
-	FacetMode           string `form:"facetMode,omitempty"`           // Choose the returned value for facet items, either count of issues or sum of remediation effort.
-	Facets              string `form:"facets,omitempty"`              // Comma-separated list of the facets to be computed. No facet is computed by default.
-	Issues              string `form:"issues,omitempty"`              // Comma-separated list of issue keys
-	Languages           string `form:"languages,omitempty"`           // Comma-separated list of languages. Available since 4.4
-	OnComponentOnly     string `form:"onComponentOnly,omitempty"`     // Return only issues at a component's level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.
-	Organization        string `form:"organization,omitempty"`        // Organization key
-	OwaspTop10          string `form:"owaspTop10,omitempty"`          // Comma-separated list of OWASP Top 10 lowercase categories.
-	PullRequest         string `form:"pullRequest,omitempty"`         // Pull request id
-	Resolutions         string `form:"resolutions,omitempty"`         // Comma-separated list of resolutions
-	Resolved            string `form:"resolved,omitempty"`            // To match resolved or unresolved issues
-	Rules               string `form:"rules,omitempty"`               // Comma-separated list of coding rule keys. Format is &lt;repository&gt;:&lt;rule&gt;
-	S                   string `form:"s,omitempty"`                   // Sort field
-	SansTop25           string `form:"sansTop25,omitempty"`           // Comma-separated list of SANS Top 25 categories.
-	Severities          string `form:"severities,omitempty"`          // Comma-separated list of severities
-	SinceLeakPeriod     string `form:"sinceLeakPeriod,omitempty"`     // To retrieve issues created since the leak period.<br>If this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.
-	SonarsourceSecurity string `form:"sonarsourceSecurity,omitempty"` // Comma-separated list of SonarSource security categories. Use 'others' to select issues not associated with any category
-	Statuses            string `form:"statuses,omitempty"`            // Comma-separated list of statuses
-	Tags                string `form:"tags,omitempty"`                // Comma-separated list of tags.
-	Types               string `form:"types,omitempty"`               // Comma-separated list of types.
+	AdditionalFields             string `form:"additionalFields,omitempty"`             // Comma-separated list of the optional fields to be returned in response. Action plans are dropped in 5.5, it is not returned in the response.
+	Asc                          string `form:"asc,omitempty"`                          // Ascending sort
+	Assigned                     string `form:"assigned,omitempty"`                     // To retrieve assigned or unassigned issues
+	Assignees                    string `form:"assignees,omitempty"`                    // Comma-separated list of assignee logins. The value '__me__' can be used as a placeholder for user who performs the request
+	Author                       string `form:"author,omitempty"`                       // SCM accounts. To set several values, the parameter must be called once for each value.
+	Branch                       string `form:"branch,omitempty"`                       // Branch key
+	CleanCodeAttributeCategories string `form:"cleanCodeAttributeCategories,omitempty"` // Comma-separated list of clean code attribute categories.
+	ComponentKeys                string `form:"componentKeys,omitempty"`                // Comma-separated list of component keys. Retrieve issues associated to a specific list of components (and all its descendants). A component can be a project, directory or file.
+	CreatedAfter                 string `form:"createdAfter,omitempty"`                 // To retrieve issues created after the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided. <br>If this parameter is set, createdSince must not be set
+	CreatedAt                    string `form:"createdAt,omitempty"`                    // Datetime to retrieve issues created during a specific analysis
+	CreatedBefore                string `form:"createdBefore,omitempty"`                // To retrieve issues created before the given date (inclusive). <br>Either a date (server timezone) or datetime can be provided.
+	CreatedInLast                string `form:"createdInLast,omitempty"`                // To retrieve issues created during a time span before the current time (exclusive). Accepted units are 'y' for year, 'm' for month, 'w' for week and 'd' for day. If this parameter is set, createdAfter must not be set
+	Cwe                          string `form:"cwe,omitempty"`                          // Comma-separated list of CWE identifiers. Use 'unknown' to select issues not associated to any CWE.
+	FacetMode                    string `form:"facetMode,omitempty"`                    // Choose the returned value for facet items, either count of issues or sum of remediation effort.
+	Facets                       string `form:"facets,omitempty"`                       // Comma-separated list of the facets to be computed. No facet is computed by default.
+	ImpactSeverities             string `form:"impactSeverities,omitempty"`             // Comma-separated list of impact severities.
+	ImpactSoftwareQualities      string `form:"impactSoftwareQualities,omitempty"`      // Comma-separated list of software qualities.
+	IssueStatuses                string `form:"issueStatuses,omitempty"`                // Comma-separated list of issue statuses
+	Issues                       string `form:"issues,omitempty"`                       // Comma-separated list of issue keys
+	Languages                    string `form:"languages,omitempty"`                    // Comma-separated list of languages. Available since 4.4
+	OnComponentOnly              string `form:"onComponentOnly,omitempty"`              // Return only issues at a component's level, not on its descendants (modules, directories, files, etc). This parameter is only considered when componentKeys or componentUuids is set.
+	Organization                 string `form:"organization,omitempty"`                 // Organization key
+	OwaspTop10                   string `form:"owaspTop10,omitempty"`                   // Comma-separated list of OWASP Top 10 lowercase categories.
+	PullRequest                  string `form:"pullRequest,omitempty"`                  // Pull request id
+	Resolutions                  string `form:"resolutions,omitempty"`                  // Comma-separated list of resolutions
+	Resolved                     string `form:"resolved,omitempty"`                     // To match resolved or unresolved issues
+	Rules                        string `form:"rules,omitempty"`                        // Comma-separated list of coding rule keys. Format is &lt;repository&gt;:&lt;rule&gt;
+	S                            string `form:"s,omitempty"`                            // Sort field
+	SansTop25                    string `form:"sansTop25,omitempty"`                    // Comma-separated list of SANS Top 25 categories.
+	Severities                   string `form:"severities,omitempty"`                   // Comma-separated list of severities
+	SinceLeakPeriod              string `form:"sinceLeakPeriod,omitempty"`              // To retrieve issues created since the leak period.<br>If this parameter is set to a truthy value, createdAfter must not be set and one component id or key must be provided.
+	SonarsourceSecurity          string `form:"sonarsourceSecurity,omitempty"`          // Comma-separated list of SonarSource security categories. Use 'others' to select issues not associated with any category
+	Tags                         string `form:"tags,omitempty"`                         // Comma-separated list of tags.
+	Types                        string `form:"types,omitempty"`                        // Comma-separated list of types.
 }
 
 // SearchResponse is the response for SearchRequest
@@ -632,6 +637,7 @@ type SearchResponseAll struct {
 }
 
 // SetSeverityRequest Change severity.<br/>Requires the following permissions:<ul>  <li>'Authentication'</li>  <li>'Browse' rights on project of the specified issue</li>  <li>'Administer Issues' rights on project of the specified issue</li></ul>
+// Deprecated: this action has been deprecated since version 25 Aug, 2023
 type SetSeverityRequest struct {
 	Issue    string `form:"issue,omitempty"`    // Issue key
 	Severity string `form:"severity,omitempty"` // New severity
@@ -782,6 +788,7 @@ type SetTagsResponse struct {
 }
 
 // SetTypeRequest Change type of issue, for instance from 'code smell' to 'bug'.<br/>Requires the following permissions:<ul>  <li>'Authentication'</li>  <li>'Browse' rights on project of the specified issue</li>  <li>'Administer Issues' rights on project of the specified issue</li></ul>
+// Deprecated: this action has been deprecated since version 25 Aug, 2023
 type SetTypeRequest struct {
 	Issue string `form:"issue,omitempty"` // Issue key
 	Type  string `form:"type,omitempty"`  // New type

--- a/sonarcloud/permissions/permissions_gen.go
+++ b/sonarcloud/permissions/permissions_gen.go
@@ -75,7 +75,7 @@ type BulkApplyTemplateRequest struct {
 type CreateTemplateRequest struct {
 	Description       string `form:"description,omitempty"`       // Description
 	Name              string `form:"name,omitempty"`              // Name
-	Organization      string `form:"organization,omitempty"`      // Key of organization, used when group name is set
+	Organization      string `form:"organization,omitempty"`      // Key of organization
 	ProjectKeyPattern string `form:"projectKeyPattern,omitempty"` // Project key pattern. Must be a valid Java regular expression
 }
 
@@ -215,7 +215,7 @@ type SearchProjectPermissionsResponseAll struct {
 
 // SearchTemplatesRequest List permission templates.<br />Requires the permission 'Administer' on the organization.
 type SearchTemplatesRequest struct {
-	Organization string `form:"organization,omitempty"` // Key of organization, used when group name is set
+	Organization string `form:"organization,omitempty"` // Key of organization
 	Q            string `form:"q,omitempty"`            // Limit search to permission template names that contain the supplied string.
 }
 

--- a/sonarcloud/project_branches/project_branches_gen.go
+++ b/sonarcloud/project_branches/project_branches_gen.go
@@ -8,7 +8,7 @@ type DeleteRequest struct {
 	Project string `form:"project,omitempty"` // Project key
 }
 
-// ListRequest List the branches of a project.<br/>Requires 'Browse' or 'Execute analysis' rights on the specified project.
+// ListRequest List the branches of a project.<br/>The statistics are the overall counts on long branches, and the count of issues detected on the changed code on short branches.Requires 'Browse' or 'Execute analysis' rights on the specified project.
 type ListRequest struct {
 	Project string `form:"project,omitempty"` // Project key
 }

--- a/sonarcloud/projects/projects_gen.go
+++ b/sonarcloud/projects/projects_gen.go
@@ -34,11 +34,13 @@ type BulkUpdateKeyResponse struct {
 
 // CreateRequest Create a project.<br/>Requires 'Create Projects' permission
 type CreateRequest struct {
-	Branch       string `form:"branch,omitempty"`       // SCM Branch of the project. The key of the project will become key:branch, for instance 'SonarQube:branch-5.0'
-	Name         string `form:"name,omitempty"`         // Name of the project. If name is longer than 500, it is abbreviated.
-	Organization string `form:"organization,omitempty"` // The key of the organization
-	Project      string `form:"project,omitempty"`      // Key of the project
-	Visibility   string `form:"visibility,omitempty"`   // Whether the created project should be visible to everyone, or only specific user/groups.<br/>If no visibility is specified, the default project visibility of the organization will be used.
+	Branch                 string `form:"branch,omitempty"`                 // SCM Branch of the project. The key of the project will become key:branch, for instance 'SonarQube:branch-5.0'
+	Name                   string `form:"name,omitempty"`                   // Name of the project. If name is longer than 500, it is abbreviated.
+	NewCodeDefinitionType  string `form:"newCodeDefinitionType,omitempty"`  // Project New Code Definition Type<br/><br/>New code definitions of the following types are allowed:<ul><li>previous_version</li><li>days</li><li>date</li><li>version</li></ul>
+	NewCodeDefinitionValue string `form:"newCodeDefinitionValue,omitempty"` // Project New Code Definition Value<br/><br/>For each new code definition type, a different value is expected:<ul><li>value is 'previous_version', when the new code definition type is previous_version</li><li>value should be a date <YYYY-MM-DD>, when the new code definition type is date</li><li>value should be version string, when the new code definition type is version</li><li>value should be a number between 1 and 90, when the new code definition type is days</li></ul>
+	Organization           string `form:"organization,omitempty"`           // The key of the organization
+	Project                string `form:"project,omitempty"`                // Key of the project
+	Visibility             string `form:"visibility,omitempty"`             // Whether the created project should be visible to everyone, or only specific user/groups.<br/>If no visibility is specified, the default project visibility of the organization will be used.
 }
 
 // CreateResponse is the response for CreateRequest

--- a/sonarcloud/rules/rules_gen.go
+++ b/sonarcloud/rules/rules_gen.go
@@ -21,32 +21,35 @@ type RepositoriesResponse struct {
 
 // SearchRequest Search for a collection of relevant rules matching a specified query.<br/>Since 5.5, following fields in the response have been deprecated :<ul><li>"effortToFixDescription" becomes "gapDescription"</li><li>"debtRemFnCoeff" becomes "remFnGapMultiplier"</li><li>"defaultDebtRemFnCoeff" becomes "defaultRemFnGapMultiplier"</li><li>"debtRemFnOffset" becomes "remFnBaseEffort"</li><li>"defaultDebtRemFnOffset" becomes "defaultRemFnBaseEffort"</li><li>"debtOverloaded" becomes "remFnOverloaded"</li></ul>
 type SearchRequest struct {
-	Activation          string `form:"activation,omitempty"`          // Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter 'qprofile' is not set.
-	ActiveSeverities    string `form:"active_severities,omitempty"`   // Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.
-	Asc                 string `form:"asc,omitempty"`                 // Ascending sort
-	AvailableSince      string `form:"available_since,omitempty"`     // Filters rules added since date. Format is yyyy-MM-dd
-	Cwe                 string `form:"cwe,omitempty"`                 // Comma-separated list of CWE identifiers. Use 'unknown' to select rules not associated to any CWE.
-	F                   string `form:"f,omitempty"`                   // Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :<ul><li>"defaultDebtRemFn" becomes "defaultRemFn"</li><li>"debtRemFn" becomes "remFn"</li><li>"effortToFixDescription" becomes "gapDescription"</li><li>"debtOverloaded" becomes "remFnOverloaded"</li></ul>
-	Facets              string `form:"facets,omitempty"`              // Comma-separated list of the facets to be computed. No facet is computed by default.
-	IncludeExternal     string `form:"include_external,omitempty"`    // Include external engine rules in the results
-	Inheritance         string `form:"inheritance,omitempty"`         // Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter 'activation' is set.
-	IsTemplate          string `form:"is_template,omitempty"`         // Filter template rules
-	Languages           string `form:"languages,omitempty"`           // Comma-separated list of languages
-	Organization        string `form:"organization,omitempty"`        // Organization key
-	OwaspTop10          string `form:"owaspTop10,omitempty"`          // Comma-separated list of OWASP Top 10 lowercase categories.
-	Q                   string `form:"q,omitempty"`                   // UTF-8 search query
-	Qprofile            string `form:"qprofile,omitempty"`            // Quality profile key to filter on. Used only if the parameter 'activation' is set.
-	Repositories        string `form:"repositories,omitempty"`        // Comma-separated list of repositories
-	RuleKey             string `form:"rule_key,omitempty"`            // Key of rule to search for
-	RuleKeys            string `form:"rule_keys,omitempty"`           // Rule keys
-	S                   string `form:"s,omitempty"`                   // Sort field
-	SansTop25           string `form:"sansTop25,omitempty"`           // Comma-separated list of SANS Top 25 categories.
-	Severities          string `form:"severities,omitempty"`          // Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.
-	SonarsourceSecurity string `form:"sonarsourceSecurity,omitempty"` // Comma-separated list of SonarSource security categories. Use 'others' to select rules not associated with any category
-	Statuses            string `form:"statuses,omitempty"`            // Comma-separated list of status codes
-	Tags                string `form:"tags,omitempty"`                // Comma-separated list of tags. Returned rules match any of the tags (OR operator)
-	TemplateKey         string `form:"template_key,omitempty"`        // Key of the template rule to filter on. Used to search for the custom rules based on this template.
-	Types               string `form:"types,omitempty"`               // Comma-separated list of types. Returned rules match any of the tags (OR operator)
+	Activation                   string `form:"activation,omitempty"`                   // Filter rules that are activated or deactivated on the selected Quality profile. Ignored if the parameter 'qprofile' is not set.
+	ActiveSeverities             string `form:"active_severities,omitempty"`            // Comma-separated list of activation severities, i.e the severity of rules in Quality profiles.
+	Asc                          string `form:"asc,omitempty"`                          // Ascending sort
+	AvailableSince               string `form:"available_since,omitempty"`              // Filters rules added since date. Format is yyyy-MM-dd
+	CleanCodeAttributeCategories string `form:"cleanCodeAttributeCategories,omitempty"` // Comma-separated list of Clean Code Attribute Categories
+	Cwe                          string `form:"cwe,omitempty"`                          // Comma-separated list of CWE identifiers. Use 'unknown' to select rules not associated to any CWE.
+	F                            string `form:"f,omitempty"`                            // Comma-separated list of the fields to be returned in response. All the fields are returned by default, except actives.Since 5.5, following fields have been deprecated :<ul><li>"defaultDebtRemFn" becomes "defaultRemFn"</li><li>"debtRemFn" becomes "remFn"</li><li>"effortToFixDescription" becomes "gapDescription"</li><li>"debtOverloaded" becomes "remFnOverloaded"</li></ul>
+	Facets                       string `form:"facets,omitempty"`                       // Comma-separated list of the facets to be computed. No facet is computed by default.
+	ImpactSeverities             string `form:"impactSeverities,omitempty"`             // Comma-separated list of Software Quality Severities
+	ImpactSoftwareQualities      string `form:"impactSoftwareQualities,omitempty"`      // Comma-separated list of Software Qualities
+	IncludeExternal              string `form:"include_external,omitempty"`             // Include external engine rules in the results
+	Inheritance                  string `form:"inheritance,omitempty"`                  // Comma-separated list of values of inheritance for a rule within a quality profile. Used only if the parameter 'activation' is set.
+	IsTemplate                   string `form:"is_template,omitempty"`                  // Filter template rules
+	Languages                    string `form:"languages,omitempty"`                    // Comma-separated list of languages
+	Organization                 string `form:"organization,omitempty"`                 // Organization key
+	OwaspTop10                   string `form:"owaspTop10,omitempty"`                   // Comma-separated list of OWASP Top 10 lowercase categories.
+	Q                            string `form:"q,omitempty"`                            // UTF-8 search query
+	Qprofile                     string `form:"qprofile,omitempty"`                     // Quality profile key to filter on. Used only if the parameter 'activation' is set.
+	Repositories                 string `form:"repositories,omitempty"`                 // Comma-separated list of repositories
+	RuleKey                      string `form:"rule_key,omitempty"`                     // Key of rule to search for
+	RuleKeys                     string `form:"rule_keys,omitempty"`                    // Rule keys
+	S                            string `form:"s,omitempty"`                            // Sort field
+	SansTop25                    string `form:"sansTop25,omitempty"`                    // Comma-separated list of SANS Top 25 categories.
+	Severities                   string `form:"severities,omitempty"`                   // Comma-separated list of default severities. Not the same than severity of rules in Quality profiles.
+	SonarsourceSecurity          string `form:"sonarsourceSecurity,omitempty"`          // Comma-separated list of SonarSource security categories. Use 'others' to select rules not associated with any category
+	Statuses                     string `form:"statuses,omitempty"`                     // Comma-separated list of status codes
+	Tags                         string `form:"tags,omitempty"`                         // Comma-separated list of tags. Returned rules match any of the tags (OR operator)
+	TemplateKey                  string `form:"template_key,omitempty"`                 // Key of the template rule to filter on. Used to search for the custom rules based on this template.
+	Types                        string `form:"types,omitempty"`                        // Comma-separated list of types. Returned rules match any of the tags (OR operator)
 }
 
 // SearchResponse is the response for SearchRequest

--- a/sonarcloud/users/users_gen.go
+++ b/sonarcloud/users/users_gen.go
@@ -40,9 +40,10 @@ type GroupsResponseAll struct {
 	} `json:"groups,omitempty"`
 }
 
-// SearchRequest Get a list of active users. <br/>The following fields are only returned when user has Administer System permission or for logged-in in user :<ul>   <li>'email'</li>   <li>'externalIdentity'</li>   <li>'externalProvider'</li>   <li>'groups'</li>   <li>'lastConnectionDate'</li>   <li>'tokensCount'</li></ul>Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.
+// SearchRequest Get a list of active users. <br/>The following fields are only returned for the logged-in user :<ul>   <li>'email'</li>   <li>'externalIdentity'</li>   <li>'externalProvider'</li>   <li>'groups'</li>   <li>'lastConnectionDate'</li>   <li>'tokensCount'</li></ul>Field 'lastConnectionDate' is only updated every hour, so it may not be accurate, for instance when a user authenticates many times in less than one hour.
 type SearchRequest struct {
-	Q string `form:"q,omitempty"` // Filter on login, name and email
+	Ids string `form:"ids,omitempty"` // Filter on a list of one or more (max 30) user identifiers (comma-separated UUID V4)
+	Q   string `form:"q,omitempty"`   // Filter on login, name and email
 }
 
 // SearchResponse is the response for SearchRequest

--- a/sonarcloud/webhooks/webhooks_gen.go
+++ b/sonarcloud/webhooks/webhooks_gen.go
@@ -111,7 +111,7 @@ type ListResponse struct {
 // UpdateRequest Update a Webhook.<br>Requires 'Administer' permission on the specified project, or global 'Administer' permission.
 type UpdateRequest struct {
 	Name    string `form:"name,omitempty"`    // new name of the webhook
-	Secret  string `form:"secret,omitempty"`  // If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the 'X-Sonar-Webhook-HMAC-SHA256' header
+	Secret  string `form:"secret,omitempty"`  // If provided, secret will be used as the key to generate the HMAC hex (lowercase) digest value in the 'X-Sonar-Webhook-HMAC-SHA256' header. If blank, any secret previously configured will be removed. If not set, the secret will remain unchanged.
 	Url     string `form:"url,omitempty"`     // new url to be called by the webhook
 	Webhook string `form:"webhook,omitempty"` // The key of the webhook to be updated, auto-generated value can be obtained through api/webhooks/create or api/webhooks/list
 }


### PR DESCRIPTION
- update webservices.json to current\* SonarCloud Web API spec 
- generate files using new webservices.json

\* as provided at https://sonarcloud.io/api/webservices/list on May 27th 2024

Secondary purpose of this PR is to update the license file.